### PR TITLE
[F] Add Additional Schema Fields

### DIFF
--- a/app/graphql/mutations/shared/accepts_doi_input.rb
+++ b/app/graphql/mutations/shared/accepts_doi_input.rb
@@ -8,6 +8,7 @@ module Mutations
 
       included do
         argument :doi, String, required: false, description: "Digital Object Identifier (see: https://doi.org)", attribute: true
+        argument :issn, String, required: false, description: "International Standard Serial Number (see: https://issn.org)", attribute: true
       end
     end
   end

--- a/app/graphql/mutations/shared/entity_arguments.rb
+++ b/app/graphql/mutations/shared/entity_arguments.rb
@@ -6,7 +6,9 @@ module Mutations
       extend ActiveSupport::Concern
 
       included do
-        argument :title, String, required: true, description: "Human readable title for the entity", attribute: true
+        argument :title, String, required: true, description: "Human-readable title for the entity", attribute: true
+
+        argument :subtitle, String, required: false, description: "Human-readable subtitle for the entity", attribute: true
 
         image_attachment! :hero_image
 

--- a/app/graphql/mutations/shared/hierarchical_entity_arguments.rb
+++ b/app/graphql/mutations/shared/hierarchical_entity_arguments.rb
@@ -8,14 +8,15 @@ module Mutations
       include Mutations::Shared::EntityArguments
 
       included do
-        argument :doi, String, required: false,
-          description: "The Digital Object Identifier for this entity. See https://doi.org",
-          attribute: true
         argument :summary, String, required: false,
-          description: "A brief description of the entity's contents",
+          description: "A brief description of the entity's contents.",
+          attribute: true
+        argument :published, Types::VariablePrecisionDateInputType, required: false,
+          description: "The date the entity was published",
           attribute: true
         argument :published_on, GraphQL::Types::ISO8601Date, required: false,
           description: "The date the entity was published",
+          deprecation_reason: "Use the variable 'published' input instead",
           attribute: true
         argument :visibility, Types::EntityVisibilityType, required: true,
           description: "What level of visibility the entity has",

--- a/app/graphql/types/collection_type.rb
+++ b/app/graphql/types/collection_type.rb
@@ -5,6 +5,8 @@ module Types
     implements Types::AccessibleType
     implements Types::EntityType
     implements Types::HierarchicalEntryType
+    implements Types::HasDOIType
+    implements Types::HasISSNType
     implements Types::ContributableType
     implements Types::HasSchemaPropertiesType
     implements Types::AttachableType

--- a/app/graphql/types/collection_type.rb
+++ b/app/graphql/types/collection_type.rb
@@ -26,9 +26,11 @@ module Types
       description: "Whether this collection has any child items"
 
     field :collections, resolver: Resolvers::SubcollectionResolver, connection: true
+    field :first_collection, resolver: Resolvers::SingleSubcollectionResolver
     field :related_collections, resolver: Resolvers::RelatedCollectionResolver, connection: true
     field :contributions, resolver: Resolvers::CollectionContributionResolver, connection: true
     field :items, resolver: Resolvers::ItemResolver, connection: true
+    field :first_item, resolver: Resolvers::SingleSubitemResolver
 
     field :access_grants, resolver: Resolvers::AccessGrants::CollectionResolver
 

--- a/app/graphql/types/community_type.rb
+++ b/app/graphql/types/community_type.rb
@@ -15,7 +15,6 @@ module Types
     field :position, Integer, null: true
     field :name, String, null: false, deprecation_reason: "Use Community.title"
     field :metadata, GraphQL::Types::JSON, null: true
-    field :title, String, null: false
 
     field :first_collection, resolver: Resolvers::SingleSubcollectionResolver
     field :first_item, resolver: Resolvers::SingleSubitemResolver

--- a/app/graphql/types/community_type.rb
+++ b/app/graphql/types/community_type.rb
@@ -17,6 +17,9 @@ module Types
     field :metadata, GraphQL::Types::JSON, null: true
     field :title, String, null: false
 
+    field :first_collection, resolver: Resolvers::SingleSubcollectionResolver
+    field :first_item, resolver: Resolvers::SingleSubitemResolver
+
     field :access_grants, resolver: Resolvers::AccessGrants::CommunityResolver
 
     field :user_access_grants, resolver: Resolvers::AccessGrants::UserCommunityResolver,

--- a/app/graphql/types/entity_type.rb
+++ b/app/graphql/types/entity_type.rb
@@ -9,6 +9,14 @@ module Types
 
     description "An entity that exists in the hierarchy."
 
+    field :title, String, null: false do
+      description "A human-readable title for the entity"
+    end
+
+    field :subtitle, String, null: true do
+      description "A human-readable subtitle for the entity"
+    end
+
     field :access_control_list, Types::AccessControlListType, null: true do
       description "Derived access control list"
     end

--- a/app/graphql/types/has_doi_type.rb
+++ b/app/graphql/types/has_doi_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module HasDOIType
+    include Types::BaseInterface
+
+    description "An entity that has a DOI"
+
+    field :doi, String, null: true do
+      description <<~TEXT
+      The Digital Object Identifier for this entity. See https://doi.org
+      TEXT
+    end
+  end
+end

--- a/app/graphql/types/has_issn_type.rb
+++ b/app/graphql/types/has_issn_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module HasISSNType
+    include Types::BaseInterface
+
+    description "An entity that has an ISSN"
+
+    field :issn, String, null: true do
+      description <<~TEXT
+      The International Standard Serial Number for this entity. See https://issn.org
+      TEXT
+    end
+  end
+end

--- a/app/graphql/types/hierarchical_entry_type.rb
+++ b/app/graphql/types/hierarchical_entry_type.rb
@@ -3,6 +3,8 @@
 module Types
   module HierarchicalEntryType
     include Types::BaseInterface
+    include Types::HasDOIType
+    include Types::HasISSNType
 
     description "A hierarchical entity, like a collection or an item."
 
@@ -13,8 +15,6 @@ module Types
       TEXT
     end
 
-    field :title, String, null: false, description: "A human-readable title for the entity"
-    field :doi, String, null: true, description: "The Digital Object Identifier for this entity. See https://doi.org"
     field :summary, String, null: true, description: "A description of the contents of the entity"
 
     field :published_on, GraphQL::Types::ISO8601Date, null: true,

--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -24,6 +24,7 @@ module Types
 
     field :contributions, resolver: Resolvers::ItemContributionResolver, connection: true
     field :items, resolver: Resolvers::SubitemResolver, connection: true
+    field :first_item, resolver: Resolvers::SingleSubitemResolver
     field :related_items, resolver: Resolvers::RelatedItemResolver, connection: true
 
     field :access_grants, resolver: Resolvers::AccessGrants::CollectionResolver

--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -5,6 +5,8 @@ module Types
     implements Types::AccessibleType
     implements Types::EntityType
     implements Types::HierarchicalEntryType
+    implements Types::HasDOIType
+    implements Types::HasISSNType
     implements Types::ContributableType
     implements Types::HasSchemaPropertiesType
     implements Types::AttachableType

--- a/app/graphql/types/variable_precision_date_input_type.rb
+++ b/app/graphql/types/variable_precision_date_input_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  class VariablePrecisionDateInputType < Types::BaseInputObject
+    description <<~TEXT
+    A corresponding input type for VariablePrecisionDate.
+    TEXT
+
+    argument :value, GraphQL::Types::ISO8601Date, required: false,
+      description: "The actual date, encoded in ISO8601 format (if available)"
+
+    argument :precision, Types::DatePrecisionType, required: true,
+      description: "The level of precision: the frontend can make decisions about how to format the associated value based on this"
+
+    def prepare
+      to_h
+    end
+  end
+end

--- a/app/models/concerns/has_schema_definition.rb
+++ b/app/models/concerns/has_schema_definition.rb
@@ -101,6 +101,16 @@ module HasSchemaDefinition
     call_operation("schemas.instances.read_properties", self, context: context)
   end
 
+  # @see Schemas::Instances::ReadProperty
+  # @param [String] full_path
+  # @param [Schemas::Properties::Context, nil] context
+  # @return [Dry::Monads::Success(Schemas::Properties::Reader)]
+  # @return [Dry::Monads::Success(Schemas::Properties::GroupReader)]
+  # @return [Dry::Monads::Failure(Symbol, String)]
+  def read_property(full_path, context: nil)
+    call_operation("schemas.instances.read_property", self, full_path, context: context)
+  end
+
   # @note For testing use only
   # @api private
   # @see Schemas::Instances::ReadPropertyContext

--- a/app/models/schema_version.rb
+++ b/app/models/schema_version.rb
@@ -32,7 +32,7 @@ class SchemaVersion < ApplicationRecord
     :identifier, :namespace, :name,
     to: :schema_definition
 
-  delegate :has_ordering?, :ordering_definition_for, :property_paths, to: :configuration, allow_nil: true
+  delegate :has_ordering?, :ordering_definition_for, :property_for, :property_paths, to: :configuration, allow_nil: true
 
   before_validation :extract_reference_paths!
 

--- a/app/operations/harvesting/metadata/jats/extract_entities.rb
+++ b/app/operations/harvesting/metadata/jats/extract_entities.rb
@@ -55,6 +55,10 @@ module Harvesting
 
             assigner.attr! :title, parsed.issue_title
 
+            assigner.prop! "volume.id", parsed.volume_id
+            assigner.prop! "volume.sortable_number", parsed.volume_sortable_number
+            assigner.prop! "volume.sequence", parsed.volume_sequence_number
+
             assigner.prop! "number", parsed.issue_number
             assigner.prop! "id", parsed.issue_id
 
@@ -76,6 +80,7 @@ module Harvesting
             assigner.attr! :summary, parsed.summary
 
             assigner.prop! "body", parsed.body
+            assigner.prop! "abstract", parsed.abstract
             assigner.prop! "online_version", parsed.online_version
 
             if parsed.pdf_url.present?

--- a/app/operations/schemas/instances/read_property.rb
+++ b/app/operations/schemas/instances/read_property.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Schemas
+  module Instances
+    class ReadProperty
+      include Dry::Monads[:do, :list, :result]
+      include WDPAPI::Deps[to_context: "schemas.instances.read_property_context", to_reader: "schemas.properties.to_reader"]
+
+      # @param [HasSchemaDefinition] schema_instance
+      # @param [String] full_path
+      # @param [Schemas::Properties::Context, nil] context
+      # @return [Schemas::Properties::Reader, Schemas::Properties::GroupReader]
+      def call(schema_instance, full_path, context: nil)
+        options = {}
+
+        options[:context] = context.kind_of?(Schemas::Properties::Context) ? context : yield(to_context.call(schema_instance))
+
+        property = schema_instance.schema_version.configuration.property_for full_path
+
+        return Failure[:unknown_property, "#{full_path} is not a known property"] if property.blank?
+
+        to_reader.call property, options
+      end
+    end
+  end
+end

--- a/app/operations/variable_precision/parse_date.rb
+++ b/app/operations/variable_precision/parse_date.rb
@@ -19,9 +19,9 @@ module VariablePrecision
 
       return Success(value) if value.kind_of?(VariablePrecisionDate)
 
-      return wrap_day(value) if value.kind_of?(Date)
-
       return wrap_day(value.to_date) if datelike? value
+
+      return wrap_day(value) if value.kind_of?(Date)
 
       case value
       when ISO_8601

--- a/app/services/graphql/constants.rb
+++ b/app/services/graphql/constants.rb
@@ -2,6 +2,9 @@
 
 module Graphql
   module Constants
+    # The default perPage size when not otherwise specified
+    DEFAULT_PER_PAGE_SIZE = 25
+
     # The maximum amount to allow per page (used in several places)
     MAX_PER_PAGE_SIZE = 50
   end

--- a/app/services/harvesting/metadata/jats/parsed.rb
+++ b/app/services/harvesting/metadata/jats/parsed.rb
@@ -79,6 +79,16 @@ module Harvesting
           text_from from_article_meta(%,./xmlns:abstract,), fallback: ""
         end
 
+        memoize def abstract
+          return if summary.blank?
+
+          {
+            content: summary,
+            lang: "en",
+            kind: "text",
+          }
+        end
+
         TITLE_CANDIDATES = [
           %,./xmlns:title-group/xmlns:article-title/text(),,
           %,./xmlns:title-group/xmlns:trans-title-group[@xml:lang="en"]/xmlns:trans-title/text(),,

--- a/app/services/resolvers/enhanced_resolver.rb
+++ b/app/services/resolvers/enhanced_resolver.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module EnhancedResolver
+    extend ActiveSupport::Concern
+
+    # @return [ActiveRecord::Relation]
+    def raw_scope
+      @search.instance_variable_get(:@scope)
+    end
+  end
+end

--- a/app/services/resolvers/first_matching.rb
+++ b/app/services/resolvers/first_matching.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module FirstMatching
+    extend ActiveSupport::Concern
+
+    include Resolvers::EnhancedResolver
+
+    included do
+      extension Resolvers::FirstMatchingExtension, resolver: self
+    end
+  end
+end

--- a/app/services/resolvers/first_matching_extension.rb
+++ b/app/services/resolvers/first_matching_extension.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class FirstMatchingExtension < GraphQL::Schema::FieldExtension
+    # @param [ActiveRecord::Relation, #first] value
+    def after_resolve(value:, **)
+      value.first
+    end
+  end
+end

--- a/app/services/resolvers/page_based_pagination.rb
+++ b/app/services/resolvers/page_based_pagination.rb
@@ -4,6 +4,8 @@ module Resolvers
   module PageBasedPagination
     extend ActiveSupport::Concern
 
+    include Resolvers::EnhancedResolver
+
     included do
       extension Resolvers::PageNumberExtension, resolver: self
     end

--- a/app/services/resolvers/single_subcollection_resolver.rb
+++ b/app/services/resolvers/single_subcollection_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Resolvers
+  # A resolver for getting the first-matching {Collection} below a {Collection}.
+  class SingleSubcollectionResolver < GraphQL::Schema::Resolver
+    include SearchObject.module(:graphql)
+
+    include Resolvers::FirstMatching
+    include Resolvers::OrderedAsEntity
+    include Resolvers::Subtreelike
+
+    description "Retrieve the first matching collection beneath this collection."
+
+    type "Types::CollectionType", null: true
+
+    graphql_name "Collection"
+
+    scope do
+      case object
+      when Collection
+        object.descendants.reorder(nil)
+      when Community
+        object.collections.reorder(nil)
+      else
+        # :nocov:
+        Collection.none
+        # :nocov:
+      end
+    end
+  end
+end

--- a/app/services/resolvers/single_subitem_resolver.rb
+++ b/app/services/resolvers/single_subitem_resolver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Resolvers
+  # A resolver for getting the first-matching {Item} below a {Item}.
+  class SingleSubitemResolver < GraphQL::Schema::Resolver
+    include SearchObject.module(:graphql)
+
+    include Resolvers::FirstMatching
+    include Resolvers::OrderedAsEntity
+    include Resolvers::Subtreelike
+
+    description "Retrieve the first matching item beneath this item."
+
+    type "Types::ItemType", null: true
+
+    graphql_name "Item"
+
+    scope do
+      case object
+      when Collection
+        object.items.reorder(nil)
+      when Community
+        object.items.reorder(nil)
+      when Item
+        object.descendants.reorder(nil)
+      else
+        # :nocov:
+        Item.none
+        # :nocov:
+      end
+    end
+  end
+end

--- a/app/services/resolvers/subcollection_resolver.rb
+++ b/app/services/resolvers/subcollection_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  # A resolver for getting {Item}s below an {Item}.
+  # A resolver for getting {Collection}s below a {Collection}.
   class SubcollectionResolver < GraphQL::Schema::Resolver
     include SearchObject.module(:graphql)
 
@@ -16,13 +16,7 @@ module Resolvers
     graphql_name "CollectionConnection"
 
     scope do
-      if object.kind_of?(Collection)
-        object.descendants
-      else
-        # :nocov:
-        Collection.none
-        # :nocov:
-      end
+      object.descendants.reorder(nil)
     end
   end
 end

--- a/app/services/resolvers/subitem_resolver.rb
+++ b/app/services/resolvers/subitem_resolver.rb
@@ -17,7 +17,7 @@ module Resolvers
 
     scope do
       if object.kind_of?(Item)
-        object.descendants
+        object.descendants.reorder(nil)
       else
         # :nocov:
         Item.none

--- a/app/services/resolvers/subtreelike.rb
+++ b/app/services/resolvers/subtreelike.rb
@@ -15,11 +15,19 @@ module Resolvers
     end
 
     def apply_node_filter_with_children(scope)
-      scope.where(parent: object)
+      if object.kind_of?(scope.model)
+        scope.where(parent: object)
+      else
+        scope.roots
+      end
     end
 
     def apply_node_filter_with_descendants(scope)
-      scope.all
+      if scope.model == Item && object.kind_of?(Collection)
+        scope.rewhere(collection_id: object.self_and_descendants.select(:id))
+      else
+        scope.all
+      end
     end
   end
 end

--- a/app/services/schemas/properties/group_definition.rb
+++ b/app/services/schemas/properties/group_definition.rb
@@ -40,6 +40,10 @@ module Schemas
         false
       end
 
+      def prefix
+        "#{full_path}."
+      end
+
       def required?
         properties.any?(&:actually_required?)
       end

--- a/app/services/schemas/versions/configuration.rb
+++ b/app/services/schemas/versions/configuration.rb
@@ -38,6 +38,26 @@ module Schemas
         end
       end
 
+      # @param [String] full_path
+      # @return [Schemas::Properties::GroupDefinition, Schemas::Properties::ScalarDefinition]
+      def property_for(full_path)
+        find_prop = ->(prop) do
+          throw :found, prop if prop.full_path == full_path
+
+          next unless prop.group?
+
+          next unless full_path.starts_with? prop.prefix
+
+          prop.properties.each(&find_prop)
+        end
+
+        catch(:found) do
+          properties.each(&find_prop)
+
+          nil
+        end
+      end
+
       # @return [<String>]
       def property_paths
         build_paths = ->(prop, paths) do

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,5 +2,7 @@
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
+Warning[:experimental] = false # Hush.
+
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,6 +16,8 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "CRUD"
   inflect.acronym "DOI"
+  inflect.acronym "ISBN"
+  inflect.acronym "ISSN"
   inflect.acronym "JATS"
   inflect.acronym "METS"
   inflect.acronym "MODS"

--- a/db/migrate/20211209180555_add_new_properties_to_entities.rb
+++ b/db/migrate/20211209180555_add_new_properties_to_entities.rb
@@ -1,0 +1,41 @@
+class AddNewPropertiesToEntities < ActiveRecord::Migration[6.1]
+  def change
+    %i[communities collections items].each do |table|
+      change_table table do |t|
+        t.text :subtitle
+      end
+    end
+
+    %i[collections items].each do |table|
+      change_table table do |t|
+        t.text :issn
+
+        t.index :issn
+      end
+    end
+
+    change_table :entities do |t|
+      t.jsonb :properties, default: {}, null: false
+
+      t.index :properties, using: :gin, opclass: :jsonb_path_ops
+    end
+
+    reversible do |dir|
+      dir.up do
+        say_with_time "Inserting initial collection entity properties" do
+          execute(<<~SQL).cmdtuples
+          UPDATE entities SET properties = jsonb_build_object('doi', parent.doi)
+          FROM collections AS parent WHERE parent.id = entities.entity_id AND entities.entity_type = 'Collection'
+          SQL
+        end
+
+        say_with_time "Inserting initial item entity properties" do
+          execute(<<~SQL).cmdtuples
+          UPDATE entities SET properties = jsonb_build_object('doi', parent.doi)
+          FROM items AS parent WHERE parent.id = entities.entity_id AND entities.entity_type = 'Item'
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/lib/schemas/definitions/nglp/journal/1.0.0.json
+++ b/lib/schemas/definitions/nglp/journal/1.0.0.json
@@ -24,6 +24,7 @@
     }
   ],
   "properties": [
+    { "path": "description", "label": "Description", "type": "full_text", "required": false },
     {
       "path": "publisher",
       "properties": [

--- a/lib/schemas/definitions/nglp/journal_article/1.0.0.json
+++ b/lib/schemas/definitions/nglp/journal_article/1.0.0.json
@@ -6,6 +6,7 @@
   "orderings": [],
   "properties": [
     { "path": "body", "label": "Full Text", "type": "full_text", "required": false, "wide": true },
+    { "path": "abstract", "label": "Abstract", "type": "full_text", "required": false, "wide": true },
     { "path": "online_version", "label": "Online Version", "type": "url", "required": false },
     { "path": "pdf_version", "label": "PDF Version", "type": "asset", "required": false },
     {

--- a/lib/schemas/definitions/nglp/journal_issue/1.0.0.json
+++ b/lib/schemas/definitions/nglp/journal_issue/1.0.0.json
@@ -5,6 +5,15 @@
   "consumer": "collection",
   "orderings": [],
   "properties": [
+    {
+      "path": "volume",
+      "legend": "Volume Metadata",
+      "properties": [
+        { "path": "id", "label": "ID", "type": "string" },
+        { "path": "sortable_number", "label": "Sortable Number", "type": "integer" }
+      ],
+      "type": "group"
+    },
     { "path": "number", "label": "Number", "type": "string" },
     { "path": "id", "label": "Identifier", "type": "string" }
   ]

--- a/spec/operations/schemas/instances/read_property_spec.rb
+++ b/spec/operations/schemas/instances/read_property_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Schemas::Instances::ReadProperty, type: :operation do
+  let(:operation) { described_class.new }
+
+  let!(:article) { FactoryBot.create :item, schema: "nglp:journal_article" }
+
+  it "can fetch a top-level scalar property" do
+    expect_calling_with(article, "body").to succeed.with(Schemas::Properties::Reader)
+  end
+
+  it "can fetch a group property" do
+    expect_calling_with(article, "volume").to succeed.with(Schemas::Properties::GroupReader)
+  end
+
+  it "can fetch a nested property" do
+    expect_calling_with(article, "issue.id").to succeed.with(Schemas::Properties::Reader)
+  end
+
+  it "handles unknown properties" do
+    expect_calling_with(article, "issue.something_missing").to monad_fail.with_key(:unknown_property)
+  end
+end

--- a/spec/requests/graphql/mutations/create_community_spec.rb
+++ b/spec/requests/graphql/mutations/create_community_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe Mutations::CreateCommunity, type: :request do
     let(:token) { token_helper.build_token has_global_admin: true }
 
     let!(:title) { Faker::Lorem.sentence }
+    let!(:subtitle) { Faker::Lorem.sentence }
 
     let!(:mutation_input) do
       {
         title: title,
+        subtitle: subtitle,
       }
     end
 
@@ -22,7 +24,8 @@ RSpec.describe Mutations::CreateCommunity, type: :request do
       {
         createCommunity: {
           community: {
-            title: title
+            title: title,
+            subtitle: subtitle,
           },
           attributeErrors: be_blank
         }
@@ -35,6 +38,7 @@ RSpec.describe Mutations::CreateCommunity, type: :request do
         createCommunity(input: $input) {
           community {
             title
+            subtitle
           }
 
           attributeErrors {

--- a/spec/requests/graphql/mutations/create_item_spec.rb
+++ b/spec/requests/graphql/mutations/create_item_spec.rb
@@ -5,12 +5,19 @@ RSpec.describe Mutations::CreateItem, type: :request do
     let(:token) { token_helper.build_token has_global_admin: true }
 
     let!(:title) { Faker::Lorem.sentence }
+    let!(:subtitle) { Faker::Lorem.sentence }
     let!(:community) { FactoryBot.create :community }
     let!(:visibility) { "VISIBLE" }
     let!(:thumbnail) do
       graphql_upload_from "spec", "data", "lorempixel.jpg"
     end
     let!(:summary) { "A test summary" }
+    let!(:published) do
+      {
+        value: "2021-10-31",
+        precision: "DAY",
+      }
+    end
 
     let!(:collection) { FactoryBot.create :collection, community: community }
 
@@ -22,6 +29,8 @@ RSpec.describe Mutations::CreateItem, type: :request do
       {
         parentId: parent.to_encoded_id,
         title: title,
+        subtitle: subtitle,
+        published: published,
         visibility: visibility,
         thumbnail: thumbnail,
         summary: summary,
@@ -39,6 +48,8 @@ RSpec.describe Mutations::CreateItem, type: :request do
         createItem: {
           item: {
             title: title,
+            subtitle: subtitle,
+            published: published,
             visibility: visibility,
             summary: summary,
             parent: { id: parent.to_encoded_id },
@@ -57,6 +68,11 @@ RSpec.describe Mutations::CreateItem, type: :request do
         createItem(input: $input) {
           item {
             title
+            subtitle
+            published {
+              value
+              precision
+            }
             visibility
             summary
             community { id }

--- a/spec/requests/graphql/query/collection_spec.rb
+++ b/spec/requests/graphql/query/collection_spec.rb
@@ -28,14 +28,6 @@ RSpec.describe "Query.collection", type: :request do
     GRAPHQL
   end
 
-  let!(:token) { nil }
-
-  let!(:graphql_variables) { {} }
-
-  def make_default_request!
-    make_graphql_request! query, token: token, variables: graphql_variables
-  end
-
   context "as an admin" do
     let(:token) { token_helper.build_token has_global_admin: true }
 
@@ -90,5 +82,17 @@ RSpec.describe "Query.collection", type: :request do
         expect_graphql_response_data collection: nil
       end
     end
+  end
+
+  it_behaves_like "a graphql type with firstCollection" do
+    let!(:collection) { FactoryBot.create :collection }
+
+    subject { collection }
+  end
+
+  it_behaves_like "a graphql type with firstItem" do
+    let!(:collection) { FactoryBot.create :collection }
+
+    subject { collection }
   end
 end

--- a/spec/requests/graphql/query/community_spec.rb
+++ b/spec/requests/graphql/query/community_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe "Query.community", type: :request do
+  it_behaves_like "a graphql type with firstCollection" do
+    let!(:community) { FactoryBot.create :community }
+
+    let!(:parent) { community }
+
+    subject { community }
+  end
+
+  it_behaves_like "a graphql type with firstItem" do
+    let!(:community) { FactoryBot.create :community }
+
+    let!(:parent) { FactoryBot.create :collection, community: community }
+
+    subject { community }
+  end
+end

--- a/spec/requests/graphql/query/item_spec.rb
+++ b/spec/requests/graphql/query/item_spec.rb
@@ -81,4 +81,10 @@ RSpec.describe "Query.item", type: :request do
       end
     end
   end
+
+  it_behaves_like "a graphql type with firstItem" do
+    let!(:item) { FactoryBot.create :item }
+
+    subject { item }
+  end
 end

--- a/spec/requests/graphql/query/page_based_pagination_spec.rb
+++ b/spec/requests/graphql/query/page_based_pagination_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+RSpec.describe "Page-Based Pagination", type: :request do
+  let!(:collection) { FactoryBot.create :collection }
+
+  let!(:subcollections) do
+    ?a.upto(?c).each_with_object({}) do |title, h|
+      key = title.to_sym
+
+      h[key] = FactoryBot.create :collection, title: title.upcase, parent: collection
+    end.tap do |h|
+      h[:d] = special_collection
+    end
+  end
+
+  let!(:test_schema) { FactoryBot.create :schema_version, :collection }
+
+  let!(:special_collection) { FactoryBot.create :collection, title: ?D, parent: collection, schema_version: test_schema }
+
+  let!(:order) { "TITLE_ASCENDING" }
+  let!(:page) { nil }
+  let!(:per_page) { nil }
+  let!(:page_direction) { "FORWARDS" }
+  let!(:before) { nil }
+  let!(:after) { nil }
+  let!(:schema_filter) { nil }
+
+  let!(:graphql_variables) do
+    {
+      slug: collection.system_slug,
+      order: order,
+      page: page,
+      per_page: per_page,
+      page_direction: page_direction,
+      before: before,
+      after: after,
+      schema: Array(schema_filter).presence,
+    }.compact
+  end
+
+  let!(:subcollection_count) { collection.children.count }
+
+  let!(:derived_page) { page || 1 if page || per_page }
+  let!(:derived_per_page) { per_page || Graphql::Constants::DEFAULT_PER_PAGE_SIZE if page || per_page }
+
+  let(:expected_page) { page }
+  let(:expected_per_page) { per_page }
+  let(:expected_page_count) { (subcollection_count.to_f / derived_per_page).ceil if derived_page && derived_per_page }
+  let(:expected_total_count) { subcollection_count }
+  let(:expected_total_unfiltered_count) { subcollection_count }
+
+  let(:expected_page_info) do
+    {
+      page: expected_page,
+      per_page: expected_per_page,
+      page_count: expected_page_count,
+      total_count: expected_total_count,
+      total_unfiltered_count: expected_total_unfiltered_count,
+    }
+  end
+
+  let!(:query) do
+    <<~GRAPHQL
+    query getSubcollections(
+      $slug: Slug!, $order: EntityOrder!, $pageDirection: PageDirection!,
+      $page: Int, $perPage: Int, $before: String, $after: String,
+      $schema: [String!]
+    ) {
+      collection(slug: $slug) {
+        collections(
+          before: $before,
+          after: $after,
+          page: $page,
+          pageDirection: $pageDirection,
+          perPage: $perPage,
+          order: $order,
+          schema: $schema,
+        ) {
+          edges {
+            node {
+              id
+            }
+          }
+
+          pageInfo {
+            page
+            perPage
+            pageCount
+            totalCount
+            totalUnfilteredCount
+          }
+        }
+      }
+    }
+    GRAPHQL
+  end
+
+  let(:expected_edges) { expect_edges :a, :b, :c, :d }
+
+  let(:expected_shape) do
+    {
+      collection: {
+        collections: {
+          edges: expected_edges,
+          page_info: expected_page_info,
+        },
+      },
+    }
+  end
+
+  def expect_edges(*keys)
+    keys.flatten.map do |key|
+      subcollection = subcollections.fetch key
+
+      { node: { id: subcollection.to_encoded_id } }
+    end
+  end
+
+  context "when fetching in ascending title order" do
+    it "gets the proper values" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+
+  context "when specifying only perPage" do
+    let(:per_page) { 2 }
+
+    let(:expected_page) { 1 }
+
+    let(:expected_edges) { super().take(2) }
+
+    it "defaults to setting page 1" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+
+  context "when specifying only page" do
+    let(:page) { 1 }
+
+    let(:expected_per_page) { Graphql::Constants::DEFAULT_PER_PAGE_SIZE }
+
+    it "defaults the global per-page default" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+
+  context "when specifying a schema filter" do
+    let(:schema_filter) { test_schema.system_slug }
+    let(:expected_total_count) { 1 }
+
+    let(:expected_edges) { expect_edges :d }
+
+    it "has the correct total count vs total unfiltered count" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+
+  shared_examples_for "an execution error" do
+    let(:top_level_error_count) { 1 }
+
+    let(:expected_message) { be_present }
+
+    let(:expected_shape) do
+      top_level_error_count.times.map do
+        {
+          message: expected_message,
+        }
+      end
+    end
+
+    it "raises an execution error" do
+      make_default_request! no_top_level_errors: false
+
+      expect_graphql_response_errors expected_shape
+    end
+  end
+
+  context "when setting before & page at the same time" do
+    let(:before) { "MQ" }
+    let(:page) { 1 }
+
+    let(:expected_message) { "Cannot specify both page and before/after cursor" }
+
+    it_behaves_like "an execution error"
+  end
+
+  context "when specifying an impossible filter" do
+    let(:page) { 1 }
+
+    let(:schema_filter) { "does_not:exist" }
+
+    let(:expected_per_page) { Graphql::Constants::DEFAULT_PER_PAGE_SIZE }
+    let(:expected_page_count) { 0 }
+    let(:expected_total_count) { 0 }
+    let(:expected_edges) { be_blank }
+
+    it "has the proper total_unfiltered_count but no results" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+
+  context "when set to a ridiculous page" do
+    let(:page) { 1000 }
+
+    let(:expected_per_page) { Graphql::Constants::DEFAULT_PER_PAGE_SIZE }
+
+    let(:expected_edges) { be_blank }
+
+    it "has the proper total_unfiltered_count but no results" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+
+  context "when set to an invalid page" do
+    let(:page) { -10 }
+
+    it_behaves_like "an execution error"
+  end
+
+  context "when set to an invalid perPage" do
+    let(:per_page) { 0 }
+
+    it_behaves_like "an execution error"
+  end
+end

--- a/spec/requests/graphql/query/schema_instance_spec.rb
+++ b/spec/requests/graphql/query/schema_instance_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+RSpec.describe "Schema Instances", type: :request do
+  let!(:article) { FactoryBot.create :item, schema: "nglp:journal_article" }
+
+  let!(:graphql_variables) { { slug: article.system_slug } }
+
+  let!(:query) do
+    <<~GRAPHQL
+    query getArticleSchemaProps($slug: Slug!) {
+      article: item(slug: $slug) {
+        body: schemaProperty(fullPath: "body") {
+          ...PropInfoFragment
+        }
+
+        volumeId: schemaProperty(fullPath: "volume.id") {
+          ... PropInfoFragment
+        }
+
+        unknown: schemaProperty(fullPath: "unknown.path") {
+          ... PropInfoFragment
+        }
+
+        schemaInstanceContext {
+          assets {
+            kind
+            label
+            value
+          }
+
+          contributors {
+            kind
+            label
+            value
+          }
+
+          entityId
+
+          fieldValues
+
+          schemaVersionSlug
+
+          validity {
+            valid
+            errors {
+              message
+            }
+          }
+        }
+      }
+    }
+
+    fragment PropInfoFragment on AnySchemaProperty {
+      __typename
+
+      ... on ScalarProperty {
+        fullPath
+        type
+      }
+
+      ... on StringProperty {
+        content
+      }
+
+      ... on FullTextProperty {
+        fullText {
+          kind
+          lang
+          content
+        }
+      }
+    }
+    GRAPHQL
+  end
+
+  let!(:expected_shape) do
+    {
+      article: {
+        body: {
+          __typename: "FullTextProperty",
+          type: "full_text",
+          full_path: "body",
+          full_text: be_blank,
+        },
+        volume_id: {
+          __typename: "StringProperty",
+          type: "string",
+          full_path: "volume.id",
+          content: be_blank,
+        },
+        unknown: be_blank,
+
+        schema_instance_context: {
+          assets: be_blank,
+          contributors: be_blank,
+          entity_id: article.to_encoded_id,
+          field_values: be_blank,
+          schema_version_slug: article.schema_version.system_slug,
+          validity: {
+            valid: false,
+            errors: be_present,
+          }
+        }
+      }
+    }
+  end
+
+  it "can retrieve information about incomplete schemas" do
+    make_default_request!
+
+    expect_graphql_response_data expected_shape, decamelize: true
+  end
+end

--- a/spec/support/helpers/graphql_helpers.rb
+++ b/spec/support/helpers/graphql_helpers.rb
@@ -33,6 +33,10 @@ module TestHelpers
         expect(graphql_response(**options)).to include_json data: shape
       end
 
+      def expect_graphql_response_errors(shape)
+        expect(graphql_response(decamelize: true)).to include_json errors: shape
+      end
+
       def graphql_response(*path, decamelize: false)
         parsed_graphql_response(decamelize: decamelize).then do |res|
           path.present? ? res.dig(*path) : res

--- a/spec/support/matchers/monadic.rb
+++ b/spec/support/matchers/monadic.rb
@@ -3,7 +3,7 @@
 RSpec::Matchers.define :be_a_monadic_success do
   match do |actual|
     if actual.success? && instance_variable_defined?(:@expected_value)
-      values_match? actual.value!, @expected_value
+      values_match? @expected_value, actual.value!
     else
       actual.success?
     end

--- a/spec/support/shared_examples/a_graphql_type_with_first_collection.rb
+++ b/spec/support/shared_examples/a_graphql_type_with_first_collection.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "a graphql type with firstCollection" do
+  subject { raise "set the subject" }
+
+  let(:parent) { subject }
+  let(:parent_key) do
+    case parent
+    when Collection then :parent
+    when Community then :community
+    else
+      raise "parent is not an collection, set parent_key"
+    end
+  end
+
+  let(:subject_field) do
+    case subject
+    when Collection then :collection
+    when Community then :community
+    when Item then :item
+    else
+      raise "set the subject_field: the field on QueryType that resolves to our subject"
+    end
+  end
+
+  describe "#firstCollection" do
+    let!(:custom_schema) { FactoryBot.create :schema_version, :collection }
+
+    let!(:subcollection_with_custom_schema) { FactoryBot.create :collection, title: "Schema", schema_version: custom_schema, parent_key => parent }
+    let!(:subcollection_a) { FactoryBot.create :collection, title: ?A, parent_key => parent }
+    let!(:subcollection_z) { FactoryBot.create :collection, title: ?Z, parent_key => parent }
+
+    let(:graphql_variables) { { slug: subject.system_slug, schema: [custom_schema.system_slug] } }
+
+    let!(:query) do
+      <<~GRAPHQL
+      query getFirstCollections($slug: Slug!, $schema: [String!]) {
+        subject: #{subject_field}(slug: $slug) {
+          custom: firstCollection(schema: $schema) {
+            id
+          }
+
+          z: firstCollection(order: TITLE_DESCENDING) {
+            id
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:expected_shape) do
+      {
+        subject: {
+          custom: { id: subcollection_with_custom_schema.to_encoded_id },
+          z: { id: subcollection_z.to_encoded_id },
+        },
+      }
+    end
+
+    it "can fetch collections by various filters and orderings" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+end

--- a/spec/support/shared_examples/a_graphql_type_with_first_item.rb
+++ b/spec/support/shared_examples/a_graphql_type_with_first_item.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "a graphql type with firstItem" do
+  subject { raise "set the subject" }
+
+  let(:parent) { subject }
+  let(:parent_key) do
+    case parent
+    when Collection then :collection
+    when Item then :parent
+    else
+      raise "parent is not an item, set parent_key"
+    end
+  end
+
+  let(:subject_field) do
+    case subject
+    when Collection then :collection
+    when Community then :community
+    when Item then :item
+    else
+      raise "set the subject_field: the field on QueryType that resolves to our subject"
+    end
+  end
+
+  describe "#firstItem" do
+    let!(:custom_schema) { FactoryBot.create :schema_version, :item }
+
+    let!(:subitem_with_custom_schema) { FactoryBot.create :item, title: "Schema", schema_version: custom_schema, parent_key => parent }
+    let!(:subitem_a) { FactoryBot.create :item, title: ?A, parent_key => parent }
+    let!(:subitem_z) { FactoryBot.create :item, title: ?Z, parent_key => parent }
+
+    let(:graphql_variables) { { slug: subject.system_slug, schema: [custom_schema.system_slug] } }
+
+    let!(:query) do
+      <<~GRAPHQL
+      query getFirstItems($slug: Slug!, $schema: [String!]) {
+        subject: #{subject_field}(slug: $slug) {
+          custom: firstItem(schema: $schema) {
+            id
+          }
+
+          z: firstItem(order: TITLE_DESCENDING) {
+            id
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:expected_shape) do
+      {
+        subject: {
+          custom: { id: subitem_with_custom_schema.to_encoded_id },
+          z: { id: subitem_z.to_encoded_id },
+        },
+      }
+    end
+
+    it "can fetch items by various filters and orderings" do
+      make_default_request!
+
+      expect_graphql_response_data expected_shape, decamelize: true
+    end
+  end
+end


### PR DESCRIPTION
* Improve page-based pagination edge cases
* Add `Community.firstCollection`, `Community.firstItem`, `Collection.firstCollection`, `Collection.firstItem`, and `Item.firstItem` to the GraphQL API.
* Add new schema properties and single field resolver for collections & items (`schemaProperty(fullPath: String!)`)

Resolves WDP-432