### PR TITLE
[C] Speed up pilot harvesting seed task

### DIFF
--- a/app/jobs/harvesting/prepare_entities_from_record_job.rb
+++ b/app/jobs/harvesting/prepare_entities_from_record_job.rb
@@ -4,6 +4,8 @@ module Harvesting
   class PrepareEntitiesFromRecordJob < ApplicationJob
     queue_as :harvesting
 
+    unique :until_and_while_executing, lock_ttl: 1.hour, on_conflict: :log
+
     # @param [HarvestRecord] harvest_record
     # @return [void]
     def perform(harvest_record)

--- a/app/jobs/harvesting/reprocess_attempt_job.rb
+++ b/app/jobs/harvesting/reprocess_attempt_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Harvesting
+  # Iterate over all harvest records for an attempt and queue a job to reprocess them.
+  class ReprocessAttemptJob < ApplicationJob
+    queue_as :maintenance
+
+    include JobIteration::Iteration
+
+    unique :until_and_while_executing, lock_ttl: 1.hour, on_conflict: :log
+
+    # @param [HarvestAttempt] harvest_attempt
+    # @return [void]
+    def build_enumerator(harvest_attempt, cursor:)
+      enumerator_builder.active_record_on_records(
+        harvest_attempt.harvest_records,
+        cursor: cursor
+      )
+    end
+
+    # @param [HarvestRecord] harvest_record
+    # @return [void]
+    def each_iteration(harvest_record, _harvest_attempt)
+      Harvesting::UpsertEntitiesForRecordJob.perform_later harvest_record, reprepare: true
+    end
+  end
+end

--- a/app/jobs/harvesting/upsert_entities_for_record_job.rb
+++ b/app/jobs/harvesting/upsert_entities_for_record_job.rb
@@ -5,6 +5,8 @@ module Harvesting
   class UpsertEntitiesForRecordJob < ApplicationJob
     queue_as :harvesting
 
+    unique :until_and_while_executing, lock_ttl: 1.hour, on_conflict: :log
+
     # @param [HarvestRecord] harvest_record
     # @param [Boolean] reprepare
     # @return [void]

--- a/app/jobs/processing/destroy_attachment_job.rb
+++ b/app/jobs/processing/destroy_attachment_job.rb
@@ -4,6 +4,8 @@ module Processing
   class DestroyAttachmentJob < ApplicationJob
     queue_as :processing
 
+    unique :until_and_while_executing, lock_ttl: 1.hour, on_conflict: :log
+
     # @return [void]
     def perform(attacher_class, data)
       attacher_class = Object.const_get(attacher_class)

--- a/app/jobs/seeding/import_vendored_job.rb
+++ b/app/jobs/seeding/import_vendored_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module PilotHarvesting
-  class SeedJob < ApplicationJob
+module Seeding
+  class ImportVendoredJob < ApplicationJob
     queue_as :maintenance
 
     unique :until_and_while_executing, lock_ttl: 1.hour, on_conflict: :log
@@ -9,7 +9,7 @@ module PilotHarvesting
     # @param [#to_s] name
     # @return [void]
     def perform(name)
-      call_operation! "pilot_harvesting.seed", name
+      call_operation! "seeding.import_vendored", name
     end
   end
 end

--- a/app/operations/harvesting/actions/manually_run_mapping.rb
+++ b/app/operations/harvesting/actions/manually_run_mapping.rb
@@ -20,11 +20,9 @@ module Harvesting
       def perform(harvest_mapping)
         attempt = yield create_manual_attempt.call harvest_mapping
 
-        yield extract_records.call attempt
+        yield extract_records.call attempt, skip_prepare: true
 
-        attempt.harvest_records.find_each do |record|
-          Harvesting::UpsertEntitiesForRecordJob.perform_later record
-        end
+        Harvesting::ReprocessAttemptJob.perform_later attempt
 
         Success attempt
       end

--- a/app/operations/harvesting/actions/manually_run_source.rb
+++ b/app/operations/harvesting/actions/manually_run_source.rb
@@ -25,11 +25,9 @@ module Harvesting
       def perform(harvest_source, target_entity, set: nil)
         attempt = yield create_manual_attempt.call harvest_source, target_entity, set: set
 
-        yield extract_records.call attempt
+        yield extract_records.call attempt, skip_prepare: true
 
-        attempt.harvest_records.find_each do |record|
-          Harvesting::UpsertEntitiesForRecordJob.perform_later record
-        end
+        Harvesting::ReprocessAttemptJob.perform_later attempt
 
         Success attempt
       end

--- a/app/operations/pilot_harvesting/seed.rb
+++ b/app/operations/pilot_harvesting/seed.rb
@@ -84,7 +84,6 @@ module PilotHarvesting
             metadata_format: "mets",
           },
         ],
-        seeds: %w[ucm_units uci_units],
       },
       umassamherst: {
         communities: [

--- a/spec/jobs/harvesting/reprocess_attempt_job_spec.rb
+++ b/spec/jobs/harvesting/reprocess_attempt_job_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Harvesting::ReprocessAttemptJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/jobs/seeding/import_vendored_job_spec.rb
+++ b/spec/jobs/seeding/import_vendored_job_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Seeding::ImportVendoredJob, type: :job do
+  it_behaves_like "a pass-through operation job", "seeding.import_vendored" do
+    let(:job_arg) { "some_name" }
+  end
+end


### PR DESCRIPTION
Asynchronize actual record processing, since some result sets can be
very large and cause the initial seed task to time out.