### PR TITLE
[E] Correct SQL dumps and restoration

### DIFF
--- a/bin/managedb
+++ b/bin/managedb
@@ -57,7 +57,9 @@ show_help() {
 backup_dump_db() {
   warn "** Dumping the database..."
 
-  pg_dump -O -x --clean --if-exists --column-inserts -w > $SQL_FILE
+  pg_dump -O -x --clean --if-exists -w -f $SQL_FILE
+
+  sed -i 's/DROP TYPE IF EXISTS public.variable_precision_date;/DROP TYPE IF EXISTS public.variable_precision_date CASCADE;/' "${SQL_FILE}"
 }
 
 backup_make_tarball() {
@@ -120,7 +122,7 @@ restore_db() {
   local dumpfile="${RESTORE_TMP}/${SQL_FILE}"
 
   if [ -f "$dumpfile" ]; then
-    psql -o /dev/null -q -P pager=off -f "$dumpfile"
+    psql -o /dev/null -q -P pager=off -v ON_ERROR_STOP=1 --single-transaction -f "$dumpfile"
   else
     warn "'${SQL_FILE}' not in backup, skipping"
   fi

--- a/db/migrate/20220308173141_rebuild_orderable_properties.rb
+++ b/db/migrate/20220308173141_rebuild_orderable_properties.rb
@@ -59,8 +59,8 @@ class RebuildOrderableProperties < ActiveRecord::Migration[6.1]
 
     def create_generate_fn_expression
       <<~SQL.strip_heredoc
-      CREATE OR REPLACE FUNCTION #{generate_fn_signature} RETURNS #{quoted_pg_type} AS $$
-      SELECT CASE WHEN $1 = #{quoted_type} THEN #{convert_fn}($2) ELSE NULL END;
+      CREATE OR REPLACE FUNCTION #{pg_schema}.#{generate_fn_signature} RETURNS #{quoted_pg_type} AS $$
+      SELECT CASE WHEN $1 = #{quoted_type} THEN #{pg_schema}.#{convert_fn}($2) ELSE NULL END;
       $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
       SQL
     end

--- a/db/migrate/20250107183852_cleanup_database.rb
+++ b/db/migrate/20250107183852_cleanup_database.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+class CleanupDatabase < ActiveRecord::Migration[7.0]
+  NEW_TABLES = %i[
+    ordering_entries
+    ordering_entry_ancestor_links
+    ordering_entry_sibling_links
+  ].freeze
+
+  NEW_TABLES_AND_PARTITIONS = NEW_TABLES.flat_map do |table|
+    [table].tap do |a|
+      1.upto(8).each do |num|
+        a << :"#{table}_part_#{num}"
+      end
+    end
+  end.freeze
+
+  OLD_TABLES = NEW_TABLES.index_with do |table|
+    :"zz_#{table}"
+  end.freeze
+
+  OLD_TABLES_AND_PARTITIONS = NEW_TABLES_AND_PARTITIONS.index_with do |table|
+    :"zz_#{table}"
+  end.freeze
+
+  def change
+    set_up_schemas!
+
+    drop_views!
+
+    move_old_tables!
+
+    create_new_unpartitioned_tables!
+
+    restore_views!
+
+    migrate_partitioned_data!
+  end
+
+  private
+
+  def set_up_schemas!
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+        DROP SCHEMA IF EXISTS heroku_ext;
+
+        CREATE SCHEMA IF NOT EXISTS legacy;
+        SQL
+      end
+
+      dir.down do
+        execute <<~SQL
+        DROP SCHEMA IF EXISTS legacy;
+        SQL
+      end
+    end
+  end
+
+  def drop_views!
+    drop_view :initial_ordering_derivations, revert_to_version: 1
+
+    reversible do |dir|
+      dir.down do
+        change_table :ordering_entry_counts do |t|
+          t.index %i[ordering_id], name: "ordering_entry_counts_pkey", unique: true
+        end
+      end
+    end
+
+    drop_view :ordering_entry_counts, materialized: true, revert_to_version: 1
+  end
+
+  def remove_old_foreign_keys!
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+        ALTER TABLE ordering_entries DROP CONSTRAINT IF EXISTS ordering_entries_ordering_id_fkey;
+        ALTER TABLE ordering_entry_ancestor_links DROP CONSTRAINT IF EXISTS ordering_entry_ancestor_links_ordering_id_fkey;
+        ALTER TABLE ordering_entry_sibling_links DROP CONSTRAINT IF EXISTS ordering_entry_sibling_links_ordering_id_fkey;
+        ALTER TABLE templates_ordering_instances DROP CONSTRAINT IF EXISTS ordering_instance_entry_fk;
+        SQL
+      end
+
+      dir.down do
+        execute <<~SQL
+        ALTER TABLE "templates_ordering_instances" ADD CONSTRAINT "ordering_instance_entry_fk"
+          FOREIGN KEY ("ordering_id", "ordering_entry_id") REFERENCES "ordering_entries" ("ordering_id", "id")
+          ON DELETE SET NULL (ordering_entry_id)
+          DEFERRABLE INITIALLY DEFERRED
+        ;
+        SQL
+      end
+    end
+  end
+
+  def move_old_tables!
+    remove_old_foreign_keys!
+
+    OLD_TABLES_AND_PARTITIONS.each do |old_name, new_name|
+      rename_table old_name, new_name
+    end
+
+    reversible do |dir|
+      dir.up do
+        OLD_TABLES_AND_PARTITIONS.each_value do |table|
+          execute <<~SQL
+          ALTER TABLE public.#{table} SET SCHEMA legacy;
+          SQL
+        end
+      end
+
+      dir.down do
+        OLD_TABLES_AND_PARTITIONS.each_value do |table|
+          execute <<~SQL
+          ALTER TABLE legacy.#{table} SET SCHEMA public;
+          SQL
+        end
+      end
+    end
+  end
+
+  def create_new_unpartitioned_tables!
+    create_ordering_entries!
+
+    create_ancestors!
+
+    create_siblings!
+  end
+
+  def restore_views!
+    create_view :ordering_entry_counts, materialized: true, version: 1
+
+    change_table :ordering_entry_counts do |t|
+      t.index %i[ordering_id], name: "ordering_entry_counts_pkey", unique: true
+    end
+
+    create_view :initial_ordering_derivations, version: 1
+  end
+
+  def create_ordering_entries!
+    create_table :ordering_entries, id: :uuid do |t|
+      t.references :ordering, type: :uuid, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.references :entity, type: :uuid, null: false, polymorphic: true, index: { name: "index_ordering_entries_references_entity" }
+      t.bigint :position, null: false
+      t.bigint :inverse_position, null: false
+      t.enum :link_operator, enum_type: "link_operator"
+      t.column :auth_path, :ltree, null: false
+      t.column :scope, :ltree, null: false
+      t.integer :relative_depth, null: false
+      t.bigint :tree_depth
+      t.references :tree_parent, type: :uuid, null: true, polymorphic: true, index: false
+
+      t.timestamp :stale_at, precision: 6
+      t.timestamps null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+      t.index %i[ordering_id entity_type entity_id], unique: true, name: "index_ordering_entries_uniqueness"
+      t.index %i[ordering_id position], name: "index_ordering_entries_sort"
+      t.index %i[ordering_id inverse_position], name: "index_ordering_entries_sort_inverse"
+      t.index %i[ordering_id scope position], name: "index_ordering_entries_sorted_by_scope", using: :gist
+      t.index %i[ordering_id stale_at], name: "index_ordering_entries_staleness", where: %[stale_at IS NOT NULL]
+      t.index %i[ordering_id tree_parent_id tree_parent_type], name: "index_ordering_entries_tree_parent"
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+        CREATE INDEX "index_ordering_entries_tree_ancestry_lookup" ON ordering_entries USING GIST (ordering_id, auth_path, tree_depth) INCLUDE (id);
+        CREATE INDEX "index_ordering_entries_tree_child_lookup" ON ordering_entries (ordering_id, auth_path) INCLUDE (tree_depth, id) WHERE tree_depth > 1;
+        SQL
+      end
+    end
+  end
+
+  def create_ancestors!
+    create_table :ordering_entry_ancestor_links, id: :uuid do |t|
+      t.references :ordering, type: :uuid, null: false, foreign_key: { on_delete: :cascade }
+      t.references :child, type: :uuid, null: false, foreign_key: { to_table: :ordering_entries, on_delete: :cascade }
+      t.references :ancestor, type: :uuid, null: false, foreign_key: { to_table: :ordering_entries, on_delete: :cascade }
+      t.bigint :inverse_depth, null: false
+      t.timestamps null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+      t.check_constraint <<~SQL.strip_heredoc.strip, name: "oeal_child_does_not_parent_itself"
+      child_id <> ancestor_id
+      SQL
+
+      t.index %i[ordering_id child_id ancestor_id inverse_depth], name: "index_ordering_entry_ancestor_links_sorting"
+      t.index %i[ordering_id child_id inverse_depth], unique: true, name: "index_ordering_entry_ancestor_links_uniqueness"
+    end
+  end
+
+  def create_siblings!
+    create_table :ordering_entry_sibling_links, id: :uuid do |t|
+      t.references :ordering, type: :uuid, null: false, foreign_key: { on_delete: :cascade }
+      t.references :sibling, type: :uuid, null: false, foreign_key: { to_table: :ordering_entries, on_delete: :cascade }
+      t.references :prev, type: :uuid, null: true, foreign_key: { to_table: :ordering_entries, on_delete: :cascade }
+      t.references :next, type: :uuid, null: true, foreign_key: { to_table: :ordering_entries, on_delete: :cascade }
+      t.timestamps null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+      t.check_constraint <<~SQL.strip_heredoc.strip, name: "oesl_child_does_not_ref_itself"
+      sibling_id <> prev_id AND sibling_id <> next_id
+      SQL
+
+      t.index %i[ordering_id sibling_id], unique: true, name: "index_ordering_entry_sibling_links_uniqueness"
+    end
+  end
+
+  def migrate_partitioned_data!
+    reversible do |dir|
+      dir.up do
+        say_with_time "Migrating ordering_entries" do
+          exec_update(<<~SQL.strip_heredoc.strip)
+          INSERT INTO ordering_entries (id, ordering_id, entity_id, entity_type, position, inverse_position, link_operator, auth_path, scope, relative_depth, tree_depth, tree_parent_id, tree_parent_type, stale_at, created_at, updated_at)
+          SELECT id, ordering_id, entity_id, entity_type, position, inverse_position, link_operator, auth_path, scope, relative_depth, tree_depth, tree_parent_id, tree_parent_type, stale_at, created_at, updated_at FROM legacy.zz_ordering_entries;
+          SQL
+        end
+
+        say_with_time "Migrating ordering_entry_ancestor_links" do
+          exec_update(<<~SQL.strip_heredoc.strip)
+          INSERT INTO ordering_entry_ancestor_links (id, ordering_id, child_id, ancestor_id, inverse_depth, created_at, updated_at)
+          SELECT id, ordering_id, child_id, ancestor_id, inverse_depth, created_at, updated_at FROM legacy.zz_ordering_entry_ancestor_links;
+          SQL
+        end
+
+        say_with_time "Migrating ordering_entry_sibling_links" do
+          exec_update(<<~SQL.strip_heredoc.strip)
+          INSERT INTO ordering_entry_sibling_links (ordering_id, sibling_id, prev_id, next_id, created_at, updated_at)
+          SELECT ordering_id, sibling_id, prev_id, next_id, created_at, updated_at FROM legacy.zz_ordering_entry_sibling_links;
+          SQL
+        end
+
+        say_with_time "restoring FK for ordering template instances" do
+          execute <<~SQL
+          ALTER TABLE "templates_ordering_instances" ADD CONSTRAINT "ordering_instance_entry_fk"
+            FOREIGN KEY ("ordering_entry_id") REFERENCES "ordering_entries" ("id")
+            ON DELETE SET NULL (ordering_entry_id)
+            DEFERRABLE INITIALLY DEFERRED
+          ;
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250107201204_fix_using_with_ltree.rb
+++ b/db/migrate/20250107201204_fix_using_with_ltree.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# JOIN USING against ltree (or other extension) values does not dump correctly in a way that can be used with an empty search path.
+class FixUsingWithLtree < ActiveRecord::Migration[7.0]
+  def change
+    drop_view :access_grant_management_links, revert_to_version: 1
+
+    update_view :contextual_permissions, version: 4, revert_to_version: 3
+    update_view :contextual_single_permissions, version: 2, revert_to_version: 1
+    update_view :contextually_assignable_roles, version: 2, revert_to_version: 1
+    update_view :contextually_assigned_access_grants, version: 2, revert_to_version: 1
+    update_view :contextually_assigned_roles, version: 3, revert_to_version: 2
+
+    create_view :access_grant_management_links, version: 1
+  end
+end

--- a/db/migrate/20250107202700_remove_self_path.rb
+++ b/db/migrate/20250107202700_remove_self_path.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Column ended up not being used and causes problems in dumps that aren't worth fixing.
+class RemoveSelfPath < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+    ALTER TABLE permissions DROP COLUMN IF EXISTS self_path_old;
+    ALTER TABLE permissions DROP COLUMN IF EXISTS self_path;
+    SQL
+  end
+
+  def down
+    # Intentionally left blank
+  end
+end

--- a/db/migrate/20250107205521_fix_functions.rb
+++ b/db/migrate/20250107205521_fix_functions.rb
@@ -1,0 +1,418 @@
+# frozen_string_literal: true
+
+class FixFunctions < ActiveRecord::Migration[7.0]
+  LANG = LANG1 = "SQL"
+  LANG2 = "plpgsql"
+
+  PATTERN = Base64.decode64(<<~BASE64.strip_heredoc)
+  XigwfFsxLTldXGQqKVwuKDB8WzEtOV1cZCopXC4oMHxbMS05XVxkKikoPzot
+  KCg/OjB8WzEtOV1cZCp8XGQqW2EtekEtWi1dWzAtOWEtekEtWi1dKikoPzpc
+  Lig/OjB8WzEtOV1cZCp8XGQqW2EtekEtWi1dWzAtOWEtekEtWi1dKikpKikp
+  Pyg/OlwrKFswLTlhLXpBLVotXSsoPzpcLlswLTlhLXpBLVotXSspKikpPyQ=
+  BASE64
+
+  def up
+    execute <<~SQL
+    CREATE OR REPLACE FUNCTION public.ltree_generations(ltree, ltree, ltree) RETURNS bigint AS $$
+    SELECT public.nlevel(
+      public.subltree(
+        $1,
+        public.index($1, $2),
+        public.index($1, $3, public.index($1, $2))
+      )
+    );
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.is_valid_semver(jsonb) RETURNS boolean AS $$
+    SELECT
+    CASE jsonb_typeof($1)
+    WHEN 'string' THEN public.is_valid_semver($1 #>> '{}')
+    ELSE
+      FALSE
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION try_cast_variable_precision_date(text) RETURNS variable_precision_date AS $$
+    BEGIN
+      BEGIN
+        RETURN CAST($1 AS public.variable_precision_date);
+      EXCEPTION WHEN OTHERS THEN
+        RETURN NULL;
+      END;
+    END;
+    $$ LANGUAGE #{LANG2} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_text(jsonb) RETURNS text AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'string' THEN $1 #>> '{}' ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_citext(jsonb) RETURNS citext AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'string' THEN CAST($1 #>> '{}' AS public.citext) ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_boolean(jsonb) RETURNS boolean AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'boolean' THEN CAST($1 #>> '{}' AS boolean) ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_numeric(jsonb) RETURNS decimal AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'number' THEN CAST ($1 #>> '{}' AS numeric) ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_bigint(jsonb) RETURNS bigint AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'number' THEN COALESCE(public.try_cast_bigint($1 #>> '{}'), CAST(CAST($1 #>> '{}' AS numeric) AS bigint)) ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_date(jsonb) RETURNS date AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'string' THEN public.try_cast_date($1 #>> '{}') ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_timestamptz(jsonb) RETURNS timestamptz AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'string' THEN public.try_cast_timestamptz($1 #>> '{}') ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_to_variable_precision_date(jsonb) RETURNS variable_precision_date AS $$
+    SELECT CASE WHEN jsonb_typeof($1) = 'string' THEN public.try_cast_variable_precision_date($1 #>> '{}') ELSE NULL END;
+    $$ LANGUAGE #{LANG1} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_set_rec(jsonb, jsonb, text[]) RETURNS jsonb AS $$
+      SELECT CASE
+      WHEN array_length($3, 1) > 1 and ($1 #> $3[:array_upper($3, 1) - 1]) is null
+      THEN public.jsonb_set_rec($1, jsonb_build_object($3[array_upper($3, 1)], $2), $3[:array_upper($3, 1) - 1])
+      ELSE jsonb_set($1, $3, $2, true)
+      END
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_extract_boolean(jsonb, text[]) RETURNS boolean AS $$
+    SELECT CASE jsonb_typeof($1 #> $2) WHEN 'boolean' THEN ($1 #> $2)::boolean ELSE FALSE END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION jsonb_bool_or_rec(jsonb, boolean, text[]) RETURNS jsonb AS $$
+    SELECT public.jsonb_set_rec($1, to_jsonb(public.jsonb_extract_boolean($1, $3) OR $2), $3);
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION array_distinct(anycompatiblearray) RETURNS anycompatiblearray AS $$
+    SELECT array_agg(DISTINCT x) FILTER (WHERE x IS NOT NULL) FROM unnest($1) t(x);
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION record_is_skipped(jsonb) RETURNS boolean AS $$
+    SELECT public.jsonb_extract_boolean($1, '{active}');
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION variable_precision_for(variable_precision_date) RETURNS public.date_precision AS $$
+    SELECT CASE
+    WHEN $1 IS NOT NULL AND $1.value IS NOT NULL AND $1.precision IS NOT NULL THEN $1.precision
+    ELSE
+      'none'::public.date_precision
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION variable_precision(date) RETURNS public.variable_precision_date AS $$
+    SELECT CASE
+    WHEN $1 IS NOT NULL THEN ROW($1, 'day')::public.variable_precision_date
+    ELSE
+      ROW(NULL, 'none')::public.variable_precision_date
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_has_value(public.variable_precision_date) RETURNS boolean AS $$
+    SELECT $1 IS NOT NULL AND OPERATOR(public.~>) $1 <> 'none'::public.date_precision;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_nullif_none(variable_precision_date) RETURNS public.variable_precision_date AS $$
+    SELECT CASE WHEN OPERATOR(public.?^) $1 THEN OPERATOR(public.@) $1 ELSE NULL END;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_normalize(public.variable_precision_date) RETURNS public.variable_precision_date AS $$
+    SELECT CASE
+    WHEN $1 IS NULL OR $1.precision = 'none'::public.date_precision THEN ROW(NULL, 'none')::public.variable_precision_date
+    ELSE
+      public.variable_precision($1.value, $1.precision)
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_value(variable_precision_date) RETURNS date AS $$
+    SELECT public.vpdate_value_for($1.value, $1.precision);
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.variable_precision(date, public.date_precision) RETURNS public.variable_precision_date AS $$
+    SELECT CASE
+    WHEN $1 IS NOT NULL AND $2 IS NOT NULL AND $2 <> 'none'::public.date_precision THEN
+    ROW(public.vpdate_value_for($1, $2), $2)::public.variable_precision_date
+    ELSE
+      ROW(NULL, 'none')::public.variable_precision_date
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.variable_precision(public.date_precision, date) RETURNS public.variable_precision_date AS $$
+    SELECT public.variable_precision($2, $1);
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.calculate_actions(jsonb) RETURNS TABLE(action public.ltree, allowed boolean) AS $$
+    WITH RECURSIVE flattened (scope, value) AS (
+      SELECT
+        grid.scope::public.ltree AS scope,
+        grid.value AS value
+        FROM jsonb_each($1) AS grid(scope, value)
+        WHERE jsonb_typeof($1) = 'object'
+      UNION ALL
+      SELECT
+        flattened.scope OPERATOR(public.||) COALESCE(grid.scope, '') AS scope,
+        grid.value AS value
+      FROM
+        flattened, jsonb_each(flattened.value) AS grid(scope, value)
+      WHERE jsonb_typeof(flattened.value) = 'object'
+    ), actions AS (
+      SELECT action.action, action.allowed
+      FROM
+        flattened,
+        public.calculate_action(flattened.scope, flattened.value) AS action(action, allowed)
+      WHERE jsonb_typeof(flattened.value) = 'boolean'
+    ) SELECT DISTINCT ON (action) action, allowed FROM actions WHERE action IS NOT NULL;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.calculate_allowed_actions(jsonb) RETURNS public.ltree[] AS $$
+    SELECT COALESCE(
+      array_agg(action ORDER BY action) FILTER (WHERE allowed),
+      '{}'::public.ltree[]
+    ) FROM public.calculate_actions($1) AS t(action, allowed)
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.calculate_role_kind(public.role_identifier) RETURNS role_kind AS $$
+    SELECT CASE
+    WHEN $1 IS NOT NULL THEN 'system'
+    ELSE
+      'custom'
+    END::public.role_kind;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.calculate_role_primacy(public.role_identifier) RETURNS public.role_primacy AS $$
+    SELECT CASE $1
+    WHEN 'admin'::public.role_identifier THEN 'high'
+    WHEN 'reader'::public.role_identifier THEN 'low'
+    ELSE
+      'default'
+    END::public.role_primacy;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.calculate_role_priority(role_identifier, smallint) RETURNS int AS $$
+    SELECT CASE
+    WHEN $1 IS NULL AND $2 IS NULL THEN NULL
+    WHEN $1 IS NOT NULL THEN public.calculate_role_priority($1)
+    ELSE
+      $2::int
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.to_schema_kind(text) RETURNS public.schema_kind AS $$
+    SELECT CASE WHEN $1 = ANY(enum_range(NULL::public.schema_kind)::text[]) THEN $1::public.schema_kind ELSE NULL END;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.parse_semver(text) RETURNS public.parsed_semver AS $$
+    SELECT (a[1], a[2], a[3], a[4], a[5])::public.parsed_semver
+    FROM (
+      SELECT
+      '#{PATTERN}'
+      AS pat
+    ) p
+    LEFT JOIN LATERAL (
+      SELECT regexp_matches($1, p.pat) AS a
+    ) match ON true
+    WHERE match.a IS NOT NULL;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_is_none(public.variable_precision_date) RETURNS boolean AS $$
+    SELECT $1 IS NULL OR OPERATOR(public.~>) $1 = 'none'::public.date_precision;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_cmp_both_valued(variable_precision_date, variable_precision_date) RETURNS boolean AS $$
+    SELECT OPERATOR(public.?^) $1 AND OPERATOR(public.?^) $2;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.vpdate_cmp_any_none(public.variable_precision_date, public.variable_precision_date) RETURNS boolean AS $$
+    SELECT OPERATOR(public.?-) $1 OR OPERATOR(public.?-) $2;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.vpdate_cmp_xor_valued(public.variable_precision_date, public.variable_precision_date) RETURNS boolean AS $$
+    SELECT
+    CASE
+    WHEN OPERATOR(public.?-) $1 THEN OPERATOR(public.?^) $2
+    WHEN OPERATOR(public.?^) $1 THEN OPERATOR(public.?-) $2
+    ELSE
+      FALSE
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.vpdate_cmp_both_none(public.variable_precision_date, public.variable_precision_date) RETURNS boolean AS $$
+    SELECT OPERATOR(public.?-) $1 AND OPERATOR(public.?-) $2;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.date_precision_cmp(public.date_precision, public.date_precision) RETURNS int AS $$
+    SELECT
+    CASE
+    WHEN OPERATOR(public.?-) $1 AND OPERATOR(public.?-) $2 THEN 0
+    -- none-valued dates sort to the end of the set
+    WHEN OPERATOR(public.?-) $1 AND OPERATOR(public.?^) $2 THEN 1
+    WHEN OPERATOR(public.?^) $2 AND OPERATOR(public.?-) $2 THEN -1
+    ELSE
+      enum_cmp($1, $2)
+    END;
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_cmp_precision(public.date_precision, public.variable_precision_date) RETURNS int AS $$
+    SELECT public.date_precision_cmp($1, OPERATOR(public.~>) $2);
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.vpdate_cmp_precision(public.variable_precision_date, public.variable_precision_date) RETURNS int AS $$
+    SELECT public.date_precision_cmp(OPERATOR(public.~>) $1, OPERATOR(public.~>) $2);
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION public.vpdate_cmp_precision(public.variable_precision_date, public.date_precision) RETURNS int AS $$
+    SELECT public.date_precision_cmp(OPERATOR(public.~>) $1, $2);
+    $$ LANGUAGE #{LANG} IMMUTABLE PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_precision_lt(variable_precision_date, date_precision) RETURNS boolean AS $$
+    SELECT $1 OPERATOR(public.~>?) $2 < 0;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_precision_le(variable_precision_date, date_precision) RETURNS boolean AS $$
+    SELECT $1 OPERATOR(public.~>?) $2 <= 0;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_precision_eq(variable_precision_date, date_precision) RETURNS boolean AS $$
+    SELECT OPERATOR(public.~>) $1 = $2;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_precision_neq(variable_precision_date, date_precision) RETURNS boolean AS $$
+    SELECT OPERATOR(public.~>) $1 <> $2;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_precision_ge(variable_precision_date, date_precision) RETURNS boolean AS $$
+    SELECT $1 OPERATOR(public.~>?) $2 >= 0;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+
+    CREATE OR REPLACE FUNCTION vpdate_precision_gt(variable_precision_date, date_precision) RETURNS boolean AS $$
+    SELECT $1 OPERATOR(public.~>?) $2 > 0;
+    $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+    SQL
+
+    PROP_TYPES.each do |prop_type|
+      execute prop_type.create_generate_fn_expression
+    end
+  end
+
+  def down
+    # Intentionally left blank
+  end
+
+  class PropType
+    LANG = "SQL".freeze
+
+    include Dry::Initializer[undefined: false].define -> do
+      param :local_type, Dry::Types["coercible.symbol"]
+      param :pg_type, Dry::Types["coercible.symbol"], default: proc { local_type }
+
+      option :custom_pg_type, Dry::Types["bool"], default: proc { false }
+      option :pg_schema, Dry::Types["string"], default: proc { "public" }
+      option :convert_fn, Dry::Types["string"], default: proc { "jsonb_to_#{pg_type}" }
+      option :column_name, Dry::Types["coercible.symbol"], default: proc { :"#{local_type}_value" }
+      option :generate_fn, Dry::Types["string"], default: proc { "generate_#{column_name}" }
+    end
+
+    def add_column_expression
+      <<~SQL.strip_heredoc.squish
+      ALTER TABLE entity_orderable_properties
+        ADD COLUMN #{column_name} #{quoted_pg_type} GENERATED ALWAYS AS (#{generate_expression}) STORED;
+      SQL
+    end
+
+    def drop_column_expression
+      <<~SQL.strip_heredoc
+      ALTER TABLE entity_orderable_properties
+        DROP COLUMN IF EXISTS #{column_name};
+      SQL
+    end
+
+    def generate_fn_signature()
+      %[#{generate_fn}(schema_property_type, jsonb)]
+    end
+
+    def create_generate_fn_expression
+      <<~SQL.strip_heredoc
+      CREATE OR REPLACE FUNCTION #{pg_schema}.#{generate_fn_signature} RETURNS #{quoted_pg_type} AS $$
+      SELECT CASE WHEN $1 = #{quoted_type} THEN #{pg_schema}.#{convert_fn}($2) ELSE NULL END;
+      $$ LANGUAGE #{LANG} IMMUTABLE STRICT PARALLEL SAFE;
+      SQL
+    end
+
+    def indices
+      [
+        build_index(index_name, "ASC NULLS LAST"),
+        build_index(inverted_index_name, "DESC NULLS LAST"),
+      ]
+    end
+
+    def quoted_type
+      quote local_type
+    end
+
+    private
+
+    def build_index(name, order, expression: index_expression)
+      [
+        expression,
+        {
+          name: name,
+          order: {
+            column_name => order
+          }
+        }
+      ]
+    end
+
+    def generate_expression
+      <<~SQL
+      #{generate_fn}("type", "raw_value")
+      SQL
+    end
+
+    def index_expression
+      %I[entity_type entity_id path #{column_name}]
+    end
+
+    def index_name
+      "index_eop_#{local_type}"
+    end
+
+    def inverted_index_name
+      "index_eop_#{local_type}_inverted"
+    end
+
+    def quote(value)
+      ApplicationRecord.connection.quote value
+    end
+
+    def quoted_pg_type
+      if custom_pg_type
+        sch = ApplicationRecord.connection.quote_schema_name pg_schema
+
+        typ = ApplicationRecord.connection.quote_column_name pg_type
+
+        "#{sch}.#{typ}"
+      else
+        pg_type
+      end
+    end
+  end
+
+  PROP_TYPES = [
+    PropType.new(:boolean),
+    PropType.new(:date),
+    PropType.new(:email, :citext, custom_pg_type: true),
+    PropType.new(:float, :numeric),
+    PropType.new(:integer, :bigint),
+    PropType.new(:string, :text),
+    PropType.new(:timestamp, :timestamptz),
+    PropType.new(:variable_date, :variable_precision_date, custom_pg_type: true),
+  ]
+
+end

--- a/db/migrate/20250107212233_remove_partitioned_tables.rb
+++ b/db/migrate/20250107212233_remove_partitioned_tables.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class RemovePartitionedTables < ActiveRecord::Migration[7.0]
+  NEW_TABLES = %i[
+    ordering_entries
+    ordering_entry_ancestor_links
+    ordering_entry_sibling_links
+  ].freeze
+
+  NEW_TABLES_AND_PARTITIONS = NEW_TABLES.flat_map do |table|
+    [table].tap do |a|
+      1.upto(8).each do |num|
+        a << :"#{table}_part_#{num}"
+      end
+    end
+  end.freeze
+
+  OLD_TABLES = NEW_TABLES.index_with do |table|
+    :"zz_#{table}"
+  end.freeze
+
+  OLD_TABLES_AND_PARTITIONS = NEW_TABLES_AND_PARTITIONS.index_with do |table|
+    :"zz_#{table}"
+  end.freeze
+
+  def up
+    OLD_TABLES_AND_PARTITIONS.each_value.reverse_each do |table|
+      execute <<~SQL.strip_heredoc
+      DROP TABLE IF EXISTS legacy.#{table};
+      SQL
+    end
+
+    execute <<~SQL
+    DROP SCHEMA IF EXISTS legacy;
+    SQL
+  end
+
+  def down
+    # Intentionally left blank
+  end
+end

--- a/db/views/.ignore
+++ b/db/views/.ignore
@@ -1,0 +1,8 @@
+contextual_permissions_v01.sql
+contextual_permissions_v02.sql
+contextual_permissions_v03.sql
+contextual_single_permissions_v01.sql
+contextually_assignable_roles_v01.sql
+contextually_assigned_access_grants_v01.sql
+contextually_assigned_roles_v01.sql
+contextually_assigned_roles_v02.sql

--- a/db/views/contextual_permissions_v04.sql
+++ b/db/views/contextual_permissions_v04.sql
@@ -1,0 +1,23 @@
+SELECT
+  hierarchical_id,
+  hierarchical_type,
+  gp.user_id,
+  true AS has_any_role,
+  bool_or(directly_assigned) AS has_direct_role,
+  array_agg(DISTINCT gp.access_grant_id) AS access_grant_ids,
+  array_agg(DISTINCT gp.role_id) AS role_ids,
+  array_agg(DISTINCT gp.action) AS allowed_actions,
+  jsonb_auth_path(gp.action, true) AS access_control_list,
+  jsonb_auth_path(subpath(gp.action, 1, nlevel(gp.action) - 1), true) FILTER (WHERE gp.action ~ 'self.*') AS grid,
+  MIN(gp.created_at) AS created_at,
+  MAX(gp.updated_at) AS updated_at
+  FROM granted_permissions gp
+  INNER JOIN authorizing_entities ent ON gp.auth_path = ent.auth_path AND gp.scope = ent.scope
+  LEFT JOIN LATERAL (
+    SELECT
+      accessible_type = hierarchical_type AND accessible_id = hierarchical_id AS directly_assigned
+  ) info ON true
+  WHERE
+  (NOT directly_assigned OR NOT gp.inferred)
+  GROUP BY 1, 2, 3
+;

--- a/db/views/contextual_single_permissions_v02.sql
+++ b/db/views/contextual_single_permissions_v02.sql
@@ -1,0 +1,18 @@
+SELECT
+  hierarchical_id,
+  hierarchical_type,
+  gp.user_id,
+  gp.permission_id,
+  gp.action,
+  gp.access_grant_id,
+  gp.role_id,
+  info.directly_assigned
+  FROM granted_permissions gp
+  INNER JOIN authorizing_entities ent ON gp.auth_path = ent.auth_path AND gp.scope = ent.scope
+  LEFT JOIN LATERAL (
+    SELECT
+      accessible_type = hierarchical_type AND accessible_id = hierarchical_id AS directly_assigned
+  ) info ON true
+  WHERE
+  (NOT directly_assigned OR NOT gp.inferred)
+;

--- a/db/views/contextually_assignable_roles_v02.sql
+++ b/db/views/contextually_assignable_roles_v02.sql
@@ -1,0 +1,20 @@
+SELECT DISTINCT ON (hierarchical_id, hierarchical_type, gp.user_id, ar.target_role_id)
+  hierarchical_id,
+  hierarchical_type,
+  gp.user_id,
+  ar.target_role_id AS role_id,
+  ar.priority
+  FROM (
+    SELECT DISTINCT user_id, accessible_id, accessible_type, role_id, auth_path, scope, inferred
+    FROM granted_permissions
+    WHERE action = 'self.manage_access'
+  ) gp
+  INNER JOIN assignable_role_targets ar ON ar.source_role_id = gp.role_id
+  INNER JOIN authorizing_entities ent ON gp.auth_path = ent.auth_path AND gp.scope = ent.scope
+  LEFT JOIN LATERAL (
+    SELECT
+      accessible_type = hierarchical_type AND accessible_id = hierarchical_id AS directly_assigned
+  ) info ON true
+  WHERE
+  (NOT directly_assigned OR NOT gp.inferred)
+;

--- a/db/views/contextually_assigned_access_grants_v02.sql
+++ b/db/views/contextually_assigned_access_grants_v02.sql
@@ -1,0 +1,15 @@
+SELECT
+  hierarchical_id,
+  hierarchical_type,
+  gp.user_id,
+  gp.access_grant_id
+  FROM granted_permissions gp
+  INNER JOIN authorizing_entities ent ON gp.auth_path = ent.auth_path AND gp.scope = ent.scope
+  LEFT JOIN LATERAL (
+    SELECT
+      accessible_type = hierarchical_type AND accessible_id = hierarchical_id AS directly_assigned
+  ) info ON true
+  WHERE
+  (NOT directly_assigned OR NOT gp.inferred)
+  GROUP BY 1, 2, 3, 4
+;

--- a/db/views/contextually_assigned_roles_v03.sql
+++ b/db/views/contextually_assigned_roles_v03.sql
@@ -1,0 +1,15 @@
+SELECT
+  hierarchical_id,
+  hierarchical_type,
+  gp.user_id,
+  gp.role_id
+  FROM granted_permissions gp
+  INNER JOIN authorizing_entities ent ON gp.auth_path = ent.auth_path AND gp.scope = ent.scope
+  LEFT JOIN LATERAL (
+    SELECT
+      accessible_type = hierarchical_type AND accessible_id = hierarchical_id AS directly_assigned
+  ) info ON true
+  WHERE
+  (NOT directly_assigned OR NOT gp.inferred)
+  GROUP BY 1, 2, 3, 4
+;

--- a/lib/frozen_record/static_cached_columns.yml
+++ b/lib/frozen_record/static_cached_columns.yml
@@ -11028,6 +11028,19 @@
   default_function: 
   has_default: false
   virtual: false
+- id: OrderingEntry#entity_type
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: entity_type
+  type: string
+  'null': false
+  sql_type_metadata:
+    sql_type: character varying
+    type: string
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
 - id: OrderingEntry#entity_id
   model_name: OrderingEntry
   table_name: ordering_entries
@@ -11041,23 +11054,24 @@
   default_function: 
   has_default: false
   virtual: false
-- id: OrderingEntry#entity_type
-  model_name: OrderingEntry
-  table_name: ordering_entries
-  name: entity_type
-  type: text
-  'null': false
-  sql_type_metadata:
-    sql_type: text
-    type: text
-  default: 
-  default_function: 
-  has_default: false
-  virtual: false
 - id: OrderingEntry#position
   model_name: OrderingEntry
   table_name: ordering_entries
   name: position
+  type: integer
+  'null': false
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: OrderingEntry#inverse_position
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: inverse_position
   type: integer
   'null': false
   sql_type_metadata:
@@ -11121,6 +11135,60 @@
   default_function: 
   has_default: false
   virtual: false
+- id: OrderingEntry#tree_depth
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: tree_depth
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: OrderingEntry#tree_parent_type
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: tree_parent_type
+  type: string
+  'null': true
+  sql_type_metadata:
+    sql_type: character varying
+    type: string
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: OrderingEntry#tree_parent_id
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: tree_parent_id
+  type: uuid
+  'null': true
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: OrderingEntry#stale_at
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: stale_at
+  type: datetime
+  'null': true
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
 - id: OrderingEntry#created_at
   model_name: OrderingEntry
   table_name: ordering_entries
@@ -11148,73 +11216,6 @@
   default: 
   default_function: CURRENT_TIMESTAMP
   has_default: true
-  virtual: false
-- id: OrderingEntry#inverse_position
-  model_name: OrderingEntry
-  table_name: ordering_entries
-  name: inverse_position
-  type: integer
-  'null': false
-  sql_type_metadata:
-    sql_type: bigint
-    type: integer
-    limit: 8
-  default: 
-  default_function: 
-  has_default: false
-  virtual: false
-- id: OrderingEntry#stale_at
-  model_name: OrderingEntry
-  table_name: ordering_entries
-  name: stale_at
-  type: datetime
-  'null': true
-  sql_type_metadata:
-    sql_type: timestamp without time zone
-    type: datetime
-  default: 
-  default_function: 
-  has_default: false
-  virtual: false
-- id: OrderingEntry#tree_depth
-  model_name: OrderingEntry
-  table_name: ordering_entries
-  name: tree_depth
-  type: integer
-  'null': true
-  sql_type_metadata:
-    sql_type: bigint
-    type: integer
-    limit: 8
-  default: 
-  default_function: 
-  has_default: false
-  virtual: false
-- id: OrderingEntry#tree_parent_id
-  model_name: OrderingEntry
-  table_name: ordering_entries
-  name: tree_parent_id
-  type: uuid
-  'null': true
-  sql_type_metadata:
-    sql_type: uuid
-    type: uuid
-  default: 
-  default_function: 
-  has_default: false
-  virtual: false
-- id: OrderingEntry#tree_parent_type
-  model_name: OrderingEntry
-  table_name: ordering_entries
-  name: tree_parent_type
-  type: text
-  'null': true
-  sql_type_metadata:
-    sql_type: text
-    type: text
-  default: 
-  default_function: 
-  has_default: false
   virtual: false
 - id: OrderingEntryAncestorLink#id
   model_name: OrderingEntryAncestorLink
@@ -11613,6 +11614,19 @@
   default: 
   default_function: 
   has_default: false
+  virtual: false
+- id: OrderingEntrySiblingLink#id
+  model_name: OrderingEntrySiblingLink
+  table_name: ordering_entry_sibling_links
+  name: id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: gen_random_uuid()
+  has_default: true
   virtual: false
 - id: OrderingEntrySiblingLink#ordering_id
   model_name: OrderingEntrySiblingLink
@@ -12065,28 +12079,6 @@
   default_function: string_to_array((path)::text, '.'::text)
   has_default: false
   virtual: true
-- id: Permission#self_path_old
-  model_name: Permission
-  table_name: permissions
-  name: self_path_old
-  type: ltree
-  'null': true
-  sql_type_metadata:
-    sql_type: ltree
-    type: ltree
-  default: 
-  default_function: |2-
-
-    CASE kind
-        WHEN 'contextual'::permission_kind THEN
-        CASE subpath(path, 0, '-1'::integer)
-            WHEN 'self'::ltree THEN NULL::ltree
-            ELSE (ltree2text('self'::ltree) || subpath(path, '-1'::integer, 1))
-        END
-        ELSE NULL::ltree
-    END
-  has_default: false
-  virtual: true
 - id: Permission#self_prefixed
   model_name: Permission
   table_name: permissions
@@ -12124,28 +12116,6 @@
     type: ltree
   default: 
   default_function: subpath(path, 1, (nlevel(path) - 1))
-  has_default: false
-  virtual: true
-- id: Permission#self_path
-  model_name: Permission
-  table_name: permissions
-  name: self_path
-  type: ltree
-  'null': true
-  sql_type_metadata:
-    sql_type: ltree
-    type: ltree
-  default: 
-  default_function: |2-
-
-    CASE kind
-        WHEN 'contextual'::permission_kind THEN
-        CASE subpath(path, 0, 1)
-            WHEN 'self'::ltree THEN NULL::ltree
-            ELSE (ltree2text('self'::ltree) || subpath(path, 1, (nlevel(path) - 1)))
-        END
-        ELSE NULL::ltree
-    END
   has_default: false
   virtual: true
 - id: Permission#head

--- a/lib/patches/set_search_path_for_dump.rb
+++ b/lib/patches/set_search_path_for_dump.rb
@@ -4,39 +4,10 @@ require "active_record/tasks/postgresql_database_tasks"
 
 module Patches
   module SetSearchPathForDump
-    DELETE = Object.new.freeze
-
     def structure_dump(filename, extra_flags)
       super
-
-      edit_file filename do |line|
-        next unless line =~ /pg_catalog\.set_config\('search_path'/
-
-        line.gsub("''", %['"$user",public'])
-      end
     ensure
       ::Support::System["column_cache.write"].call.value!
-    end
-
-    def edit_file(filename)
-      Tempfile.open(".#{File.basename(filename)}", File.dirname(filename)) do |tempfile|
-        File.open(filename).each do |line|
-          new_line = yield line
-
-          next if new_line == DELETE
-
-          if new_line.blank?
-            tempfile.puts line
-          else
-            tempfile.puts new_line
-          end
-        end
-
-        tempfile.fdatasync
-        tempfile.close
-
-        FileUtils.mv tempfile.path, filename
-      end
     end
   end
 end


### PR DESCRIPTION
* Remove partitioning on ordering entry tables. It is overkill and breaks database restorations.
* Fix functions that break during inline restoration
* Correct USING declaration in views that rely on the = operator for ltree, since that's a long-standing bug in PG that doesn't support restorations
* Remove unused column on permissions table that cannot be easily restored
* Correct managedb script
  * Add workaround to drop variable date type, since operators are not being dropped correctly for some reason