### PR TITLE
[E] Combine controlled vocabularies with contributions

### DIFF
--- a/app/graphql/mutations/update_contribution.rb
+++ b/app/graphql/mutations/update_contribution.rb
@@ -4,14 +4,31 @@ module Mutations
   class UpdateContribution < Mutations::BaseMutation
     description <<~TEXT
     Update a Contribution by ID.
+
+    **Note**: Neither the contribution role nor the contributor can be changed
+    by this mutation. Rather than deal with uniqueness violations, it's necessary
+    to delete the old contribution and create a new one with the correct role
+    or contributor.
     TEXT
 
     field :contribution, Types::AnyContributionType, null: true
 
     argument :contribution_id, ID, loads: Types::ContributionType, required: true
 
-    argument :role, String, required: false, description: "An arbitrary text value that describes the kind of contribution"
-    argument :metadata, Types::ContributionMetadataInputType, required: false
+    argument :role, String, required: false, as: :deprecated_role, description: "An arbitrary text value that describes the kind of contribution",
+      deprecation_reason: "No longer used"
+
+    argument :metadata, Types::ContributionMetadataInputType, required: false do
+      description <<~TEXT
+      Metadata for the contribution. If not provided, it will keep whatever is there.
+      TEXT
+    end
+
+    argument :position, Int, required: false do
+      description <<~TEXT
+      Sorting discriminator for the contribution. If not provided, it will keep whatever is there.
+      TEXT
+    end
 
     performs_operation! "mutations.operations.update_contribution"
   end

--- a/app/graphql/mutations/update_global_configuration.rb
+++ b/app/graphql/mutations/update_global_configuration.rb
@@ -11,6 +11,14 @@ module Mutations
       description "Though a global configuration always exists, this will be null if it fails to apply for some reason."
     end
 
+    argument :contribution_roles, Types::ContributionRoleConfigurationInputType, required: false, attribute: true do
+      description <<~TEXT
+      Optional settings for configuring contribution roles globally.
+
+      **Note**: If left blank, it will not apply anything.
+      TEXT
+    end
+
     argument :entities, Types::Settings::EntitiesSettingsInputType, required: false, attribute: true do
       description "Possible new settings for entity behavior"
     end

--- a/app/graphql/mutations/upsert_contribution.rb
+++ b/app/graphql/mutations/upsert_contribution.rb
@@ -12,8 +12,23 @@ module Mutations
     argument :contributable_id, ID, loads: Types::ContributableType, required: true
     argument :contributor_id, ID, loads: Types::AnyContributorType, required: true
 
-    argument :role, String, required: false, description: "An arbitrary text value that describes the kind of contribution"
-    argument :metadata, Types::ContributionMetadataInputType, required: false
+    argument :role_id, ID, loads: Types::ControlledVocabularyItemType, required: false,
+      description: "If not provided, it will use the default role."
+
+    argument :role, String, as: :deprecated_role, required: false, transient: true, description: "An arbitrary text value that describes the kind of contribution",
+      deprecation_reason: "No longer used"
+
+    argument :metadata, Types::ContributionMetadataInputType, required: false do
+      description <<~TEXT
+      Metadata for the contribution. If not provided, it will keep whatever is there.
+      TEXT
+    end
+
+    argument :position, Int, required: false do
+      description <<~TEXT
+      Sorting discriminator for the contribution. If not provided, it will keep whatever is there.
+      TEXT
+    end
 
     performs_operation! "mutations.operations.upsert_contribution"
   end

--- a/app/graphql/types/attributable_type.rb
+++ b/app/graphql/types/attributable_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module AttributableType
+    include Types::BaseInterface
+
+    description "A record that can retrieve flattened contributions"
+
+    field :attributions, [Types::AttributionType, { null: false }], null: false do
+      description "A priority-ordered list of attributions for the record."
+    end
+  end
+end

--- a/app/graphql/types/attribution_type.rb
+++ b/app/graphql/types/attribution_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  module AttributionType
+    include Types::BaseInterface
+
+    field :contributor, Types::ContributorBaseType, null: false
+
+    field :roles, [Types::ControlledVocabularyItemType, { null: false }], null: false do
+      description <<~TEXT
+      A priority-ordered list of the roles the associated contributor had.
+      TEXT
+    end
+
+    load_association! :contributor
+
+    load_association! :roles
+  end
+end

--- a/app/graphql/types/collection_attribution_type.rb
+++ b/app/graphql/types/collection_attribution_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  # @see CollectionAttribution
+  class CollectionAttributionType < Types::AbstractModel
+    description <<~TEXT
+    Attributions for collections.
+    TEXT
+
+    implements Types::AttributionType
+
+    field :contributor, Types::ContributorBaseType, null: false
+  end
+end

--- a/app/graphql/types/collection_type.rb
+++ b/app/graphql/types/collection_type.rb
@@ -3,6 +3,7 @@
 module Types
   class CollectionType < Types::AbstractModel
     implements Types::AccessibleType
+    implements Types::AttributableType
     implements Types::EntityType
     implements Types::ChildEntityType
     implements Types::HasEntityAnalytics
@@ -17,6 +18,10 @@ module Types
     use_direct_connection_and_edge!
 
     description "A collection of items"
+
+    field :attributions, [Types::CollectionAttributionType, { null: false }], null: false do
+      description "Attributions for the collection."
+    end
 
     field :community, Types::CommunityType, null: false
 
@@ -43,6 +48,8 @@ module Types
 
     field :user_group_access_grants, resolver: Resolvers::AccessGrants::UserGroupCollectionResolver,
       description: "Not presently used"
+
+    load_association! :attributions
 
     # @return [Boolean]
     def has_collections

--- a/app/graphql/types/contributable_type.rb
+++ b/app/graphql/types/contributable_type.rb
@@ -6,6 +6,15 @@ module Types
 
     description "Something that can be contributed to"
 
+    field :contribution_roles, Types::ContributionRoleConfigurationType, null: false do
+      description "Look up contribution role configuration for this record."
+    end
+
     field :contributors, resolver: Resolvers::ContributorResolver, description: "Contributors to this element"
+
+    # @return [ContributionRoleConfiguration]
+    def contribution_roles
+      call_operation("contribution_roles.fetch_config", contributable: object).value_or(nil)
+    end
   end
 end

--- a/app/graphql/types/contribution_base_type.rb
+++ b/app/graphql/types/contribution_base_type.rb
@@ -22,14 +22,46 @@ module Types
 
     field :metadata, Types::ContributionMetadataType, null: false
 
-    field :role, String, null: true, description: "An arbitrary text value describing the role the contributor had"
+    field :contribution_role, Types::ControlledVocabularyItemType, null: false, description: "The actual role"
 
-    field :display_name, String, null: false, description: "A potentially-overridden display name value for all contributor types"
+    field :position, Int, null: true do
+      description <<~TEXT
+      An optional sorting discriminator to decide which contribution ranks higher.
+      TEXT
+    end
 
-    field :title, String, null: true, description: "A potentially-overridden value from person contributors"
+    field :role, String, null: true, description: "An arbitrary text value describing the role the contributor had",
+      deprecation_reason: "Use `roleLabel` instead."
 
-    field :affiliation, String, null: true, description: "A potentially-overridden value from person contributors"
+    field :role_label, String, null: true do
+      description "An arbitrary text value describing the role the contributor had"
+    end
 
-    field :location, String, null: true, description: "A potentially-overridden value from organization contributors"
+    field :display_name, String, null: false do
+      description "A potentially-overridden display name value for all contributor types"
+    end
+
+    field :title, String, null: true do
+      description "A potentially-overridden value from person contributors"
+    end
+
+    field :affiliation, String, null: true do
+      description "A potentially-overridden value from person contributors"
+    end
+
+    field :location, String, null: true do
+      description "A potentially-overridden value from organization contributors"
+    end
+
+    load_association! :role, as: :contribution_role
+
+    def role
+      role_label
+    end
+
+    # @return [Promise(String)]
+    def role_label
+      contribution_role.then(&:label)
+    end
   end
 end

--- a/app/graphql/types/contribution_role_configuration_input_type.rb
+++ b/app/graphql/types/contribution_role_configuration_input_type.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Types
+  # @see ContributionRoleConfiguration
+  class ContributionRoleConfigurationInputType < Types::HashInputObject
+    description <<~TEXT
+    Configuration for the controlled vocabulary used for contribution roles on a given `source`.
+    TEXT
+
+    argument :controlled_vocabulary_id, ID, loads: Types::ControlledVocabularyType, required: true do
+      description <<~TEXT
+      The set of items to use for contribution roles for this source.
+      TEXT
+    end
+
+    argument :default_item_id, ID, loads: Types::ControlledVocabularyItemType, required: true do
+      description <<~TEXT
+      The default item to use when a contribution is created but no role is provided.
+      This is necessary as a fallback for harvesting and other use cases.
+      TEXT
+    end
+
+    argument :other_item_id, ID, loads: Types::ControlledVocabularyItemType, required: false do
+      description <<~TEXT
+      The "other" item in the set, if available (logic to be implemented later).
+      TEXT
+    end
+  end
+end

--- a/app/graphql/types/contribution_role_configuration_type.rb
+++ b/app/graphql/types/contribution_role_configuration_type.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Types
+  # @see ContributionRoleConfiguration
+  class ContributionRoleConfigurationType < Types::AbstractModel
+    description <<~TEXT
+    Configuration for the controlled vocabulary used for contribution roles on a given `source`.
+    TEXT
+
+    field :controlled_vocabulary, Types::ControlledVocabularyType, null: false do
+      description <<~TEXT
+      The set of items to use for contribution roles for this source.
+      TEXT
+    end
+
+    field :default_item, Types::ControlledVocabularyItemType, null: false do
+      description <<~TEXT
+      The default item to use when a contribution is created but no role is provided.
+      This is necessary as a fallback for harvesting and other use cases.
+      TEXT
+    end
+
+    field :other_item, Types::ControlledVocabularyItemType, null: true do
+      description <<~TEXT
+      The "other" item in the set, if available (logic to be implemented later).
+      TEXT
+    end
+
+    load_association! :controlled_vocabulary
+    load_association! :default_item
+    load_association! :other_item
+  end
+end

--- a/app/graphql/types/controlled_vocabulary_item_type.rb
+++ b/app/graphql/types/controlled_vocabulary_item_type.rb
@@ -25,6 +25,18 @@ module Types
       TEXT
     end
 
+    field :priority, Integer, null: true do
+      description <<~TEXT
+      An optional priority for certain programmatic sorting tasks within Meru API.
+      TEXT
+    end
+
+    field :tags, [String, { null: false }], null: false do
+      description <<~TEXT
+      Optional tags used for certain programmatic tasks within Meru API.
+      TEXT
+    end
+
     field :url, String, null: true do
       description <<~TEXT
       An optional URL that should be linked to if present, using the `label` as link text,

--- a/app/graphql/types/global_configuration_type.rb
+++ b/app/graphql/types/global_configuration_type.rb
@@ -9,6 +9,12 @@ module Types
 
     description "The global configuration for this installation of Meru."
 
+    field :contribution_roles, Types::ContributionRoleConfigurationType, null: false do
+      description <<~TEXT
+      Global configuration for contribution roles.
+      TEXT
+    end
+
     field :entities, Types::Settings::EntitiesSettingsType, null: false do
       description "Settings specific to how entities should behave on this installation."
     end
@@ -32,6 +38,8 @@ module Types
     field :theme, Types::Settings::ThemeSettingsType, null: false do
       description "Settings specific to the site's theme"
     end
+
+    load_association! :contribution_role_configuration, as: :contribution_roles
 
     # @return [ImageAttachments::SiteLogoWrapper]
     def logo

--- a/app/graphql/types/item_attribution_type.rb
+++ b/app/graphql/types/item_attribution_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  # @see ItemAttribution
+  class ItemAttributionType < Types::AbstractModel
+    description <<~TEXT
+    Attributions for items.
+    TEXT
+
+    implements Types::AttributionType
+  end
+end

--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -3,6 +3,7 @@
 module Types
   class ItemType < Types::AbstractModel
     implements Types::AccessibleType
+    implements Types::AttributableType
     implements Types::EntityType
     implements Types::ChildEntityType
     implements Types::HasEntityAnalytics
@@ -17,6 +18,10 @@ module Types
     use_direct_connection_and_edge!
 
     description "An item that belongs to a collection"
+
+    field :attributions, [Types::ItemAttributionType, { null: false }], null: false do
+      description "Attributions for the item."
+    end
 
     field :collection, Types::CollectionType, null: false
     field :community, Types::CommunityType, null: false
@@ -38,6 +43,8 @@ module Types
 
     field :user_group_access_grants, resolver: Resolvers::AccessGrants::UserGroupCollectionResolver,
       description: "Not presently used"
+
+    load_association! :attributions
 
     # @return [Boolean]
     def has_items

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -99,6 +99,14 @@ module Types
       end
     end
 
+    field :contribution_roles, Types::ContributionRoleConfigurationType, null: false do
+      description "Look up contribution role configuration for a given contributable (or globally)."
+
+      argument :contributable_id, ID, loads: Types::ContributableType, required: false do
+        description "The contributable to load for, if applicable."
+      end
+    end
+
     field :contributors, resolver: Resolvers::ContributorResolver do
       description "A list of all contributors in the system"
     end
@@ -191,6 +199,12 @@ module Types
       Community.by_title(title).first.tap do |community|
         track_entity_event! community
       end
+    end
+
+    # @param [Contributable, nil] contributable
+    # @return [ContributionRoleConfiguration]
+    def contribution_roles(contributable: nil)
+      call_operation("contribution_roles.fetch_config", contributable:).value_or(nil)
     end
 
     def contributor(slug:)

--- a/app/jobs/attributions/collections/manage_job.rb
+++ b/app/jobs/attributions/collections/manage_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Collections
+    # @see Attributions::Collections::Manage
+    class ManageJob < ApplicationJob
+      queue_as :maintenance
+
+      # @return [void]
+      def perform
+        call_operation!("attributions.collections.manage")
+      end
+    end
+  end
+end

--- a/app/jobs/attributions/items/manage_job.rb
+++ b/app/jobs/attributions/items/manage_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Items
+    # @see Attributions::Collections::Manage
+    class ManageJob < ApplicationJob
+      queue_as :maintenance
+
+      # @return [void]
+      def perform
+        call_operation!("attributions.items.manage")
+      end
+    end
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -20,6 +20,7 @@ class Collection < ApplicationRecord
 
   belongs_to :community, inverse_of: :collections
 
+  has_many :attributions, -> { in_default_order }, class_name: "CollectionAttribution", dependent: :delete_all, inverse_of: :collection
   has_many :contributions, class_name: "CollectionContribution", dependent: :destroy, inverse_of: :collection
 
   has_many :contributors, through: :contributions

--- a/app/models/collection_attribution.rb
+++ b/app/models/collection_attribution.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CollectionAttribution < ApplicationRecord
+  include Attribution
+  include HasEphemeralSystemSlug
+  include TimestampScopes
+
+  ATTRIBUTED_TUPLE = %i[collection_id contributor_id].freeze
+
+  belongs_to :collection, inverse_of: :attributions
+  belongs_to :contributor, inverse_of: :collection_attributions
+
+  has_many_readonly :contributions,
+    class_name: "CollectionContribution",
+    primary_key: ATTRIBUTED_TUPLE,
+    foreign_key: ATTRIBUTED_TUPLE
+
+  has_many :roles, -> { in_default_order }, through: :contributions, source: :role
+end

--- a/app/models/concerns/attribution.rb
+++ b/app/models/concerns/attribution.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# An attribution is a "flattened" version of a {Contribution} record,
+# allowing a single attribution record per {Contributable} for each
+# {Contributor}, ranked by the derived priorities of the associated roles.
+module Attribution
+  extend ActiveSupport::Concern
+  extend DefinesMonadicOperation
+
+  included do
+    scope :in_default_order, -> { reorder(position: :asc) }
+  end
+end

--- a/app/models/concerns/configures_contribution_role.rb
+++ b/app/models/concerns/configures_contribution_role.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ConfiguresContributionRole
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :contribution_role_configuration, as: :source, inverse_of: :source, autosave: true, dependent: :destroy
+  end
+end

--- a/app/models/concerns/contributable.rb
+++ b/app/models/concerns/contributable.rb
@@ -1,26 +1,56 @@
 # frozen_string_literal: true
 
+# A concern for records that may have any number of {Contribution contributions} from a {Contributor}.
+#
+# @see Collection
+# @see Item
 module Contributable
   extend ActiveSupport::Concern
+  extend DefinesMonadicOperation
 
   included do
+    extend Dry::Core::ClassAttributes
+
+    defines :contributable_foreign_key, type: Contributions::Types::ContributableForeignKey
+    defines :contributable_key, type: Contributions::Types::ContributableKey
+    defines :contributions_klass_name, type: Contributions::Types::ContributionKlassName
+
+    contributable_key :"#{model_name.singular}"
+    contributable_foreign_key :"#{contributable_key}_id"
+    contributions_klass_name "#{model_name}Contribution"
+
     delegate :contributions_klass, to: :class
   end
 
-  # @return [(Class, Hash, (:contributor_id, Symbol))]
-  def for_upsert_contribution_mutation(contributor: nil)
-    foreign_key = :"#{model_name.singular}_id"
+  # @see Contributions::Attach
+  # @see Contributions::Attacher
+  # @return [Dry::Monads::Success(Contribution)]
+  monadic_operation! def attach_contribution(contributor, **options)
+    call_operation("contributions.attach", contributor, self, **options)
+  end
 
-    attributes = {}
-    attributes[:contributor_id] = contributor.id if contributor.present?
-    attributes[foreign_key] = id
+  # @!attribute [r] contributable_foreign_key
+  # @return [Contributions::Types::ContributableForeignKey]
+  def contributable_foreign_key
+    self.class.contributable_foreign_key
+  end
 
-    [contributions_klass, attributes, %I[contributor_id #{foreign_key}]]
+  # @!attribute [r] contributable_key
+  # @return [Contributions::Types::ContributableKey]
+  def contributable_key
+    self.class.contributable_key
+  end
+
+  # @!attribute [r] contributions_klass_name
+  # @return [Contributions::Types::ContributionKlassName]
+  def contributions_klass_name
+    self.class.contributions_klass_name
   end
 
   module ClassMethods
+    # @return [Class<::Contribution>]
     def contributions_klass
-      @contributions_klass ||= reflect_on_association(:contributions).klass
+      @contributions_klass ||= contributions_klass_name.constantize
     end
   end
 end

--- a/app/models/concerns/hierarchical_entity.rb
+++ b/app/models/concerns/hierarchical_entity.rb
@@ -5,6 +5,7 @@ module HierarchicalEntity
   extend DefinesMonadicOperation
 
   include AssociationHelpers
+  include ConfiguresContributionRole
   include EntityTemplating
   include HasSystemSlug
   include Liquifies

--- a/app/models/contribution_role_configuration.rb
+++ b/app/models/contribution_role_configuration.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ContributionRoleConfiguration < ApplicationRecord
+  include HasEphemeralSystemSlug
+  include TimestampScopes
+
+  belongs_to :controlled_vocabulary, inverse_of: :contribution_role_configurations
+
+  has_many :controlled_vocabulary_items, through: :controlled_vocabulary
+
+  belongs_to :default_item, class_name: "ControlledVocabularyItem", inverse_of: :default_item_configurations
+  belongs_to :other_item, class_name: "ControlledVocabularyItem", inverse_of: :other_item_configurations, optional: true
+  belongs_to :source, polymorphic: true, inverse_of: :contribution_role_configuration
+
+  validates :source_id, uniqueness: { scope: :source_type }
+
+  before_validation :set_defaults!, on: :create
+
+  # @return [void]
+  def reset!
+    self.controlled_vocabulary = ControlledVocabulary.system_default_contribution_roles
+
+    self.default_item = controlled_vocabulary.controlled_vocabulary_items.first_tagged_with("default")
+
+    self.other_item = controlled_vocabulary.controlled_vocabulary_items.first_tagged_with("other")
+  end
+
+  private
+
+  # @return [void]
+  def set_defaults!
+    self.controlled_vocabulary ||= ControlledVocabulary.system_default_contribution_roles
+
+    self.default_item ||= controlled_vocabulary.controlled_vocabulary_items.first_tagged_with("default")
+
+    self.other_item ||= controlled_vocabulary.controlled_vocabulary_items.first_tagged_with("other")
+  end
+end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -17,9 +17,11 @@ class Contributor < ApplicationRecord
 
   has_many :harvest_contributors, inverse_of: :contributor, dependent: :nullify
 
+  has_many :collection_attributions, dependent: :delete_all, inverse_of: :contributor
   has_many :collection_contributions, dependent: :destroy, inverse_of: :contributor
   has_many :collections, through: :collection_contributions
 
+  has_many :item_attributions, dependent: :delete_all, inverse_of: :contributor
   has_many :item_contributions, dependent: :destroy, inverse_of: :contributor
   has_many :items, through: :item_contributions
 

--- a/app/models/global_configuration.rb
+++ b/app/models/global_configuration.rb
@@ -8,6 +8,7 @@
 # @see Settings::Theme
 # @see SiteLogoUploader
 class GlobalConfiguration < ApplicationRecord
+  include ConfiguresContributionRole
   include SiteLogoUploader::Attachment.new(:logo)
   include TimestampScopes
 
@@ -22,11 +23,17 @@ class GlobalConfiguration < ApplicationRecord
 
   validates :entities, :institution, :site, :theme, store_model: true
 
+  validates :contribution_role_configuration, presence: { on: :update }
+
   before_validation :maybe_clear_logo_mode!
+
+  before_validation :enforce_contribution_role_config!
 
   # @api private
   # @return [void]
   def reset!
+    contribution_role_configuration.try(:reset!)
+
     entities.reset!
 
     institution.reset!
@@ -37,6 +44,13 @@ class GlobalConfiguration < ApplicationRecord
   end
 
   private
+
+  # Ensures that a {ContributionRoleConfig} exists on the {GlobalConfiguration}.
+  #
+  # @return [void]
+  def enforce_contribution_role_config!
+    contribution_role_configuration || build_contribution_role_configuration
+  end
 
   # If a logo is set, we should set the logo mode to `with_text` or `sans_text`.
   #

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,6 +19,7 @@ class Item < ApplicationRecord
 
   belongs_to :collection, inverse_of: :items
 
+  has_many :attributions, -> { in_default_order }, class_name: "ItemAttribution", dependent: :delete_all, inverse_of: :item
   has_many :contributions, class_name: "ItemContribution", dependent: :destroy, inverse_of: :item
   has_many :contributors, through: :contributions
 

--- a/app/models/item_attribution.rb
+++ b/app/models/item_attribution.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ItemAttribution < ApplicationRecord
+  include Attribution
+  include HasEphemeralSystemSlug
+  include TimestampScopes
+
+  ATTRIBUTED_TUPLE = %i[item_id contributor_id].freeze
+
+  belongs_to :item, inverse_of: :attributions
+  belongs_to :contributor, inverse_of: :item_attributions
+
+  has_many_readonly :contributions,
+    class_name: "ItemContribution",
+    primary_key: ATTRIBUTED_TUPLE,
+    foreign_key: ATTRIBUTED_TUPLE
+
+  has_many :roles, -> { in_default_order }, through: :contributions, source: :role
+end

--- a/app/models/schema_definition.rb
+++ b/app/models/schema_definition.rb
@@ -5,6 +5,7 @@
 #
 # @subsystem Schema
 class SchemaDefinition < ApplicationRecord
+  include ConfiguresContributionRole
   include Schemas::Static::Namespaced
   include TimestampScopes
 

--- a/app/models/schema_version.rb
+++ b/app/models/schema_version.rb
@@ -7,6 +7,7 @@
 # @see Schemas::Versions::Configuration
 # @subsystem Schema
 class SchemaVersion < ApplicationRecord
+  include ConfiguresContributionRole
   include Liquifies
   include Schemas::Properties::CompilesToSchema
   include Schemas::Static::Namespaced

--- a/app/operations/attributions/collections/manage.rb
+++ b/app/operations/attributions/collections/manage.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Collections
+    # @api private
+    # @see Attribution
+    # @see Collection
+    # @see CollectionAttribution
+    # @see CollectionContribution
+    # @see Contribution
+    class Manage
+      include Dry::Monads[:result, :do]
+
+      include MeruAPI::Deps[
+        upsert: "attributions.collections.upsert",
+        prune: "attributions.collections.prune",
+      ]
+
+      # @param [Collection, nil] collection
+      # @return [Dry::Monads::Success(Hash)]
+      def call(collection: nil)
+        upserted = yield upsert.(collection:)
+
+        pruned = yield prune.(collection:)
+
+        status = { upserted:, pruned:, }
+
+        Success status
+      end
+    end
+  end
+end

--- a/app/operations/attributions/collections/prune.rb
+++ b/app/operations/attributions/collections/prune.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Collections
+    # @api private
+    # @see Attribution
+    # @see Collection
+    # @see CollectionAttribution
+    # @see CollectionContribution
+    # @see Contribution
+    class Prune
+      include Dry::Monads[:result]
+
+      include QueryOperation
+
+      PREFIX = <<~SQL
+      DELETE FROM collection_attributions AS at
+      WHERE at.id IN (
+        SELECT at.id FROM collection_attributions at
+        LEFT OUTER JOIN collection_contributions cont USING (collection_id, contributor_id)
+        WHERE cont.id IS NULL
+      SQL
+
+      SUFFIX = <<~SQL
+      )
+      SQL
+
+      # @param [Collection, nil] collection
+      # @return [Dry::Monads::Success(Integer)]
+      def call(collection: nil)
+        id_eq = with_quoted_id_for(collection, <<~SQL)
+        at.collection_id = %1$s
+        SQL
+
+        cond = compile_and(id_eq, prefix: true)
+
+        query = compile_query PREFIX, cond, SUFFIX, cond
+
+        result = sql_delete! query
+
+        Success result
+      end
+    end
+  end
+end

--- a/app/operations/attributions/collections/upsert.rb
+++ b/app/operations/attributions/collections/upsert.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Collections
+    # @api private
+    # @see Attribution
+    # @see Collection
+    # @see CollectionAttribution
+    # @see CollectionContribution
+    # @see Contribution
+    class Upsert
+      include Dry::Monads[:result]
+
+      include QueryOperation
+
+      PREFIX = <<~SQL
+      WITH attributed AS (
+        SELECT DISTINCT ON (cont.collection_id, cont.contributor_id)
+          cont.collection_id,
+          cont.contributor_id,
+          dense_rank() OVER w AS position
+        FROM collection_contributions cont
+        INNER JOIN controlled_vocabulary_items cvi ON cvi.id = cont.role_id
+        INNER JOIN contributors cbtr ON cbtr.id = cont.contributor_id
+      SQL
+
+      SUFFIX = <<~SQL
+        WINDOW w AS (
+          PARTITION BY cont.collection_id
+          ORDER BY cvi.priority DESC NULLS LAST, cvi.position ASC, cvi.identifier ASC, cont.position ASC NULLS LAST, cbtr.sort_name ASC
+        )
+      )
+      INSERT INTO collection_attributions (collection_id, contributor_id, position, created_at, updated_at)
+      SELECT collection_id, contributor_id, position, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM attributed
+      ON CONFLICT (collection_id, contributor_id) DO UPDATE SET
+        position = EXCLUDED.position,
+        updated_at =
+          CASE
+          WHEN collection_attributions.position IS DISTINCT FROM EXCLUDED.position
+          THEN excluded.updated_at
+          ELSE collection_attributions.updated_at
+          END
+      SQL
+
+      # @param [Collection, nil] collection
+      # @return [Dry::Monads::Success(Integer)]
+      def call(collection: nil)
+        cond = with_quoted_id_for(collection, <<~SQL)
+        WHERE cont.collection_id = %1$s
+        SQL
+
+        query = compile_query PREFIX, cond, SUFFIX
+
+        result = sql_update! query
+
+        Success result
+      end
+    end
+  end
+end

--- a/app/operations/attributions/items/manage.rb
+++ b/app/operations/attributions/items/manage.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Items
+    # @api private
+    # @see Attribution
+    # @see Item
+    # @see ItemAttribution
+    # @see ItemContribution
+    # @see Contribution
+    class Manage
+      include Dry::Monads[:result, :do]
+
+      include MeruAPI::Deps[
+        upsert: "attributions.items.upsert",
+        prune: "attributions.items.prune",
+      ]
+
+      # @param [Item, nil] item
+      # @return [Dry::Monads::Success(Hash)]
+      def call(item: nil)
+        upserted = yield upsert.(item:)
+
+        pruned = yield prune.(item:)
+
+        status = { upserted:, pruned:, }
+
+        Success status
+      end
+    end
+  end
+end

--- a/app/operations/attributions/items/prune.rb
+++ b/app/operations/attributions/items/prune.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Items
+    # @api private
+    # @see Attribution
+    # @see Item
+    # @see ItemAttribution
+    # @see ItemContribution
+    # @see Contribution
+    class Prune
+      include Dry::Monads[:result]
+
+      include QueryOperation
+
+      PREFIX = <<~SQL
+      DELETE FROM item_attributions AS at
+      WHERE at.id IN (
+        SELECT at.id FROM item_attributions at
+        LEFT OUTER JOIN item_contributions cont USING (item_id, contributor_id)
+        WHERE cont.id IS NULL
+      SQL
+
+      SUFFIX = <<~SQL
+      )
+      SQL
+
+      # @param [Item, nil] item
+      # @return [Dry::Monads::Success(Integer)]
+      def call(item: nil)
+        id_eq = with_quoted_id_for(item, <<~SQL)
+        at.item_id = %1$s
+        SQL
+
+        cond = compile_and(id_eq, prefix: true)
+
+        query = compile_query PREFIX, cond, SUFFIX, cond
+
+        result = sql_delete! query
+
+        Success result
+      end
+    end
+  end
+end

--- a/app/operations/attributions/items/upsert.rb
+++ b/app/operations/attributions/items/upsert.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Attributions
+  module Items
+    # @api private
+    # @see Attribution
+    # @see Item
+    # @see ItemAttribution
+    # @see ItemContribution
+    # @see Contribution
+    class Upsert
+      include Dry::Monads[:result]
+
+      include QueryOperation
+
+      PREFIX = <<~SQL
+      WITH attributed AS (
+        SELECT DISTINCT ON (cont.item_id, cont.contributor_id)
+          cont.item_id,
+          cont.contributor_id,
+          dense_rank() OVER w AS position
+        FROM item_contributions cont
+        INNER JOIN controlled_vocabulary_items cvi ON cvi.id = cont.role_id
+        INNER JOIN contributors cbtr ON cbtr.id = cont.contributor_id
+      SQL
+
+      SUFFIX = <<~SQL
+        WINDOW w AS (
+          PARTITION BY cont.item_id
+          ORDER BY cvi.priority DESC NULLS LAST, cvi.position ASC, cvi.identifier ASC, cont.position ASC NULLS LAST, cbtr.sort_name ASC
+        )
+      )
+      INSERT INTO item_attributions (item_id, contributor_id, position, created_at, updated_at)
+      SELECT item_id, contributor_id, position, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM attributed
+      ON CONFLICT (item_id, contributor_id) DO UPDATE SET
+        position = EXCLUDED.position,
+        updated_at =
+          CASE
+          WHEN item_attributions.position IS DISTINCT FROM EXCLUDED.position
+          THEN excluded.updated_at
+          ELSE item_attributions.updated_at
+          END
+      SQL
+
+      # @param [Item, nil] item
+      # @return [Dry::Monads::Success(Integer)]
+      def call(item: nil)
+        cond = with_quoted_id_for(item, <<~SQL)
+        WHERE cont.item_id = %1$s
+        SQL
+
+        query = compile_query PREFIX, cond, SUFFIX
+
+        result = sql_update! query
+
+        Success result
+      end
+    end
+  end
+end

--- a/app/operations/contribution_roles/fetch_config.rb
+++ b/app/operations/contribution_roles/fetch_config.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  # @see ContributionRoles::ConfigFetcher
+  class FetchConfig < Support::SimpleServiceOperation
+    service_klass ContributionRoles::ConfigFetcher
+  end
+end

--- a/app/operations/contribution_roles/fetch_default.rb
+++ b/app/operations/contribution_roles/fetch_default.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  # @see ContributionRoles::DefaultFetcher
+  class FetchDefault < Support::SimpleServiceOperation
+    service_klass ContributionRoles::DefaultFetcher
+  end
+end

--- a/app/operations/contribution_roles/fetch_vocabulary.rb
+++ b/app/operations/contribution_roles/fetch_vocabulary.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  # @see ContributionRoles::VocabularyFetcher
+  class FetchVocabulary < Support::SimpleServiceOperation
+    service_klass ContributionRoles::VocabularyFetcher
+  end
+end

--- a/app/operations/contributions/attach.rb
+++ b/app/operations/contributions/attach.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Contributions
+  # @see Contributions::Attacher
+  class Attach < Support::SimpleServiceOperation
+    service_klass Contributions::Attacher
+  end
+end

--- a/app/operations/contributors/attach.rb
+++ b/app/operations/contributors/attach.rb
@@ -1,24 +1,8 @@
 # frozen_string_literal: true
 
 module Contributors
-  class Attach
-    include Dry::Monads[:result, :do]
-    include MeruAPI::Deps[
-      attach_collection: "contributors.attach_collection",
-      attach_item: "contributors.attach_item",
-    ]
-
-    def call(contributor, contributable)
-      case contributable
-      when Collection
-        attach_collection.call(contributor, contributable)
-      when Item
-        attach_item.call(contributor, contributable)
-      else
-        # :nocov:
-        Failure[:invalid_contributable, "#{contributable.inspect} is not contributable"]
-        # :nocov:
-      end
-    end
+  # @deprecated Use {Contributions::Attach} instead.
+  class Attach < Support::SimpleServiceOperation
+    service_klass Contributions::Attacher
   end
 end

--- a/app/operations/contributors/attach_collection.rb
+++ b/app/operations/contributors/attach_collection.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
 module Contributors
-  class AttachCollection
-    include Dry::Monads[:result, :do]
-    include MeruAPI::Deps[count: "contributors.count_collections"]
-
-    def call(contributor, collection)
-      contribution = contributor.collection_contributions.where(collection:).first_or_initialize
-
-      contribution.save!
-
-      yield count.call(contributor)
-
-      Success contribution
-    end
+  # @deprecated Use {Contributions::Attach} instead.
+  class AttachCollection < Support::SimpleServiceOperation
+    service_klass Contributions::Attacher
   end
 end

--- a/app/operations/contributors/attach_item.rb
+++ b/app/operations/contributors/attach_item.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
 module Contributors
-  class AttachItem
-    include Dry::Monads[:result, :do]
-    include MeruAPI::Deps[count: "contributors.count_items"]
-
-    def call(contributor, item)
-      contribution = contributor.item_contributions.where(item:).first_or_initialize
-
-      contribution.save!
-
-      yield count.call(contributor)
-
-      Success contribution
-    end
+  # @deprecated Use {Contributions::Attach} instead.
+  class AttachItem < Support::SimpleServiceOperation
+    service_klass Contributions::Attacher
   end
 end

--- a/app/operations/controlled_vocabularies/contracts/item.rb
+++ b/app/operations/controlled_vocabularies/contracts/item.rb
@@ -12,6 +12,8 @@ module ControlledVocabularies
         required(:identifier).value(:identifier)
         required(:label).value(:label)
         optional(:description).maybe(:description)
+        optional(:priority).maybe(:priority)
+        optional(:tags).maybe(:tags)
         optional(:url).maybe(:url)
         optional(:unselectable).value(:bool)
         optional(:children).array(:hash)

--- a/app/operations/controlled_vocabularies/rerank_items.rb
+++ b/app/operations/controlled_vocabularies/rerank_items.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ControlledVocabularies
+  # Calculate the `ranking` value on {ControlledVocabularyItem},
+  # optionally scoped by {ControlledVocabulary}.
+  #
+  # @see ControlledVocabulary#rerank_item
+  class RerankItems
+    include Dry::Monads[:result]
+    include QueryOperation
+
+    PREFIX = <<~SQL
+    WITH rankings AS (
+      SELECT
+        id,
+        dense_rank() OVER w AS ranking
+        FROM controlled_vocabulary_items
+    SQL
+
+    SUFFIX = <<~SQL
+        WINDOW w AS (
+          PARTITION BY controlled_vocabulary_id, parent_id
+          ORDER BY priority DESC NULLS LAST, position ASC, identifier ASC
+        )
+    )
+    UPDATE controlled_vocabulary_items SET ranking = rankings.ranking
+    FROM rankings WHERE rankings.id = controlled_vocabulary_items.id;
+    SQL
+
+    # @param [ControlledVocabulary, nil] controlled_vocabulary
+    # @return [Dry::Monads::Success(Integer)]
+    def call(controlled_vocabulary: nil)
+      conditions = compile_where(controlled_vocabulary:)
+
+      count = sql_update!(PREFIX, conditions, SUFFIX)
+
+      Success count
+    end
+
+    private
+
+    # @param [ControlledVocabulary, nil] controlled_vocabulary
+    # @return [String]
+    def compile_where(controlled_vocabulary: nil)
+      with_quoted_id_for(controlled_vocabulary, <<~SQL)
+      WHERE controlled_vocabulary_id = %1$s
+      SQL
+    end
+  end
+end

--- a/app/operations/harvesting/contributions/attach.rb
+++ b/app/operations/harvesting/contributions/attach.rb
@@ -2,6 +2,7 @@
 
 module Harvesting
   module Contributions
+    # TODO: Fix during harvesting refactor.
     class Attach
       include Dry::Monads[:do, :result]
       include MonadicPersistence
@@ -16,6 +17,16 @@ module Harvesting
       # @param [Contributable] contributable
       # @return [Dry::Monads::Result]
       def call(harvest_contribution, contributable)
+        Success()
+      end
+
+      private
+
+      # @param [HarvestContribution] harvest_contribution
+      # @param [Contributable] contributable
+      # @return [Dry::Monads::Result]
+      def original_call(harvest_contribution, contributable)
+        # :nocov:
         contributor = yield connect_or_create.call(harvest_contribution.harvest_contributor)
 
         contribution = yield attach.call contributor, contributable
@@ -29,6 +40,7 @@ module Harvesting
         end
 
         monadic_save contribution
+        # :nocov:
       end
     end
   end

--- a/app/operations/mutations/contracts/update_global_configuration.rb
+++ b/app/operations/mutations/contracts/update_global_configuration.rb
@@ -5,6 +5,12 @@ module Mutations
     # @see Mutations::Operations::UpdateGlobalConfiguration
     class UpdateGlobalConfiguration < ApplicationContract
       json do
+        optional(:contribution_roles).maybe(:hash) do
+          required(:controlled_vocabulary).value(:controlled_vocabulary)
+          required(:default_item).value(:controlled_vocabulary_item)
+          optional(:other_item).value(:controlled_vocabulary_item)
+        end
+
         optional(:entities).maybe(:hash) do
           required(:suppress_external_links).value(:bool)
         end
@@ -27,6 +33,22 @@ module Mutations
           required(:color).value(included_in?: Settings::Types::COLOR_SCHEMES)
           required(:font).value(included_in?: Settings::Types::FONT_SCHEMES)
         end
+      end
+
+      rule("contribution_roles.default_item") do
+        vocab = values.dig(:contribution_roles, :controlled_vocabulary)
+
+        next if value.blank? || vocab.blank? || value.controlled_vocabulary == vocab
+
+        key.failure(:mismatched_vocabulary_item)
+      end
+
+      rule("contribution_roles.other_item") do
+        vocab = values.dig(:contribution_roles, :controlled_vocabulary)
+
+        next if value.blank? || vocab.blank? || value.controlled_vocabulary == vocab
+
+        key.failure(:mismatched_vocabulary_item)
       end
     end
   end

--- a/app/operations/mutations/operations/update_contribution.rb
+++ b/app/operations/mutations/operations/update_contribution.rb
@@ -8,6 +8,8 @@ module Mutations
       def call(contribution:, **attributes)
         authorize contribution, :update?
 
+        attributes.delete(:deprecated_role)
+
         contribution.assign_attributes attributes
 
         persist_model! contribution, attach_to: :contribution

--- a/app/operations/mutations/operations/update_global_configuration.rb
+++ b/app/operations/mutations/operations/update_global_configuration.rb
@@ -11,7 +11,7 @@ module Mutations
 
       attachment! :logo, image: true
 
-      def call(entities: nil, institution: nil, site: nil, theme: nil, **args)
+      def call(contribution_roles: nil, entities: nil, institution: nil, site: nil, theme: nil, **args)
         config = GlobalConfiguration.fetch
 
         authorize config, :update?
@@ -31,6 +31,10 @@ module Mutations
         config.theme = theme if theme.present?
 
         assign_attributes!(config, **args)
+
+        if contribution_roles.present?
+          config.contribution_role_configuration.assign_attributes(contribution_roles)
+        end
 
         persist_model! config, attach_to: :global_configuration
       end

--- a/app/operations/mutations/operations/upsert_contribution.rb
+++ b/app/operations/mutations/operations/upsert_contribution.rb
@@ -8,13 +8,11 @@ module Mutations
       def call(contributable:, contributor:, **inputs)
         authorize contributable, :update?
 
-        klass, attributes, unique_by = contributable.for_upsert_contribution_mutation(contributor:)
+        inputs.delete(:deprecated_role)
 
-        # Currently aliased
-        attributes[:kind] = inputs[:role] if inputs.key?(:role)
-        attributes[:metadata] = inputs[:metadata] if inputs[:metadata].present?
+        result = contributable.attach_contribution(contributor, **inputs)
 
-        upsert_model! klass, attributes, unique_by:, attach_to: :contribution
+        with_attached_result! :contribution, result
       end
     end
   end

--- a/app/policies/contribution_role_configuration_policy.rb
+++ b/app/policies/contribution_role_configuration_policy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# @see ContributionRoleConfiguration
+class ContributionRoleConfigurationPolicy < ApplicationPolicy
+  def read?
+    true
+  end
+
+  def upsert?
+    user.has_global_admin_access?
+  end
+
+  alias create? upsert?
+  alias update? upsert?
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/services/contribution_roles/config_fetcher.rb
+++ b/app/services/contribution_roles/config_fetcher.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  # @see ContributionRoles::FetchConfig
+  class ConfigFetcher < Support::HookBased::Actor
+    include Dry::Initializer[undefined: false].define -> do
+      option :contributable, ContributionRoles::Types::Contributable.optional, optional: true
+    end
+
+    standard_execution!
+
+    # @return [ContributionRoleConfiguration]
+    attr_reader :contribution_role_configuration
+
+    delegate :schema_version, to: :contributable, prefix: true
+
+    delegate :contribution_role_configuration, to: :contributable_schema_version, prefix: :contributable_schema
+
+    # @return [Dry::Monads::Success(ContributionRoleConfiguration)]
+    def call
+      run_callbacks :execute do
+        yield prepare!
+      end
+
+      Success contribution_role_configuration
+    end
+
+    wrapped_hook! def prepare
+      @contribution_role_configuration = nil
+
+      @contribution_role_configuration ||= find_for_contributable
+
+      @contribution_role_configuration ||= fetch_global_configuration
+
+      # :nocov:
+      raise "No default contribution role configuration." if contribution_role_configuration.blank?
+      # :nocov:
+
+      super
+    end
+
+    private
+
+    # @return [ContributionRoleConfiguration]
+    def fetch_global_configuration
+      global_configuration = GlobalConfiguration.fetch
+
+      global_configuration.contribution_role_configuration
+    end
+
+    # @return [ContributionRoleConfiguration, nil]
+    def find_for_contributable
+      return nil if contributable.blank?
+
+      entity = contributable
+
+      loop do
+        break if entity.nil?
+
+        config = entity.contribution_role_configuration
+
+        return config if config.present?
+
+        entity = entity.hierarchical_parent
+      end
+
+      contributable.schema_version.contribution_role_configuration
+    end
+  end
+end

--- a/app/services/contribution_roles/default_fetcher.rb
+++ b/app/services/contribution_roles/default_fetcher.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  # @see ContributionRoles::FetchDefault
+  class DefaultFetcher < Support::HookBased::Actor
+    include Dry::Initializer[undefined: false].define -> do
+      option :contributable, ContributionRoles::Types::Contributable.optional, optional: true
+    end
+
+    standard_execution!
+
+    # @return [ContributionRoleConfiguration]
+    attr_reader :contribution_role_configuration
+
+    # @return [ControlledVocabularyItem]
+    attr_reader :default_item
+
+    # @return [GlobalConfiguration]
+    attr_reader :global_configuration
+
+    # @return [Dry::Monads::Success(ControlledVocabularyItem)]
+    def call
+      run_callbacks :execute do
+        yield prepare!
+      end
+
+      Success default_item
+    end
+
+    wrapped_hook! def prepare
+      @contribution_role_configuration = call_operation!("contribution_roles.fetch_config", contributable:)
+
+      @default_item = contribution_role_configuration.default_item
+
+      super
+    end
+  end
+end

--- a/app/services/contribution_roles/types.rb
+++ b/app/services/contribution_roles/types.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  module Types
+    include Dry.Types
+
+    extend Support::EnhancedTypes
+
+    Contributable = ModelInstance("Collection") | ModelInstance("Item")
+
+    Role = ModelInstance("ControlledVocabularyItem")
+  end
+end

--- a/app/services/contribution_roles/vocabulary_fetcher.rb
+++ b/app/services/contribution_roles/vocabulary_fetcher.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ContributionRoles
+  # @see ContributionRoles::FetchVocabulary
+  class VocabularyFetcher < Support::HookBased::Actor
+    include Dry::Initializer[undefined: false].define -> do
+      option :contributable, ContributionRoles::Types::Contributable.optional, optional: true
+    end
+
+    standard_execution!
+
+    # @return [ContributionRoleConfiguration]
+    attr_reader :contribution_role_configuration
+
+    # @return [ControlledVocabulary]
+    attr_reader :vocabulary
+
+    # @return [Dry::Monads::Success(ControlledVocabulary)]
+    def call
+      run_callbacks :execute do
+        yield prepare!
+      end
+
+      Success vocabulary
+    end
+
+    wrapped_hook! def prepare
+      @contribution_role_configuration = call_operation!("contribution_roles.fetch_config", contributable:)
+
+      @vocabulary = contribution_role_configuration.controlled_vocabulary
+
+      super
+    end
+  end
+end

--- a/app/services/contributions/attacher.rb
+++ b/app/services/contributions/attacher.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Contributions
+  # This will upsert a {Contribution} for the combination of its inputs.
+  #
+  # @see Contributions::Attach
+  class Attacher < Support::HookBased::Actor
+    include Dry::Initializer[undefined: false].define -> do
+      param :contributor, Contributions::Types::Contributor
+
+      param :contributable, Contributions::Types::Contributable
+
+      option :role, Contributions::Types::Role.optional, as: :provided_role, optional: true
+
+      option :position, Contributions::Types::Integer.optional, optional: true
+    end
+
+    standard_execution!
+
+    # @return [::Contribution]
+    attr_reader :contribution
+
+    # @return [ControlledVocabularyItem]
+    attr_reader :role
+
+    # @return [Hash]
+    attr_reader :tuple
+
+    # @return [<Symbol>]
+    attr_reader :unique_by
+
+    delegate :contributable_foreign_key, :contributions_klass, to: :contributable
+    delegate :contributable_key, :contributables_key, to: :contributions_klass
+
+    delegate :id, to: :contributable, prefix: true
+    delegate :id, to: :contributor, prefix: true
+    delegate :id, to: :role, prefix: true
+
+    # @return [Dry::Monads::Success(Contribution)]
+    def call
+      run_callbacks :execute do
+        yield prepare!
+
+        yield upsert!
+
+        yield recount!
+
+        yield manage_attributions!
+      end
+
+      Success contribution
+    end
+
+    wrapped_hook! def prepare
+      @role = provided_role || call_operation!("contribution_roles.fetch_default", contributable:)
+
+      @tuple = build_tuple
+
+      @unique_by = [:contributor_id, contributable_foreign_key, :role_id]
+
+      super
+    end
+
+    wrapped_hook! def upsert
+      result = contributions_klass.upsert(tuple, unique_by:, returning: :id)
+
+      contribution_id = result.pick("id")
+
+      @contribution = contributions_klass.find(contribution_id)
+
+      super
+    end
+
+    wrapped_hook! def recount
+      operation = "contributors.count_#{contributables_key}"
+
+      yield call_operation(operation, contributor)
+
+      super
+    end
+
+    wrapped_hook! def manage_attributions
+      operation = "attributions.#{contributables_key}.manage"
+
+      options = {
+        contributable_key => contributable
+      }
+
+      yield call_operation(operation, **options)
+
+      super
+    end
+
+    private
+
+    def build_tuple
+      { contributor_id:, role_id:, position:, }.compact.tap do |h|
+        h[contributable_foreign_key] = contributable_id
+      end
+    end
+  end
+end

--- a/app/services/contributions/types.rb
+++ b/app/services/contributions/types.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Contributions
+  module Types
+    include Dry.Types
+
+    extend Support::EnhancedTypes
+
+    Contributable = ModelInstance("Collection") | ModelInstance("Item")
+
+    ContributableKlassName = Coercible::String.enum("Collection", "Item")
+
+    ContributableForeignKey = Coercible::Symbol.enum(:collection_id, :item_id)
+
+    ContributableKey = Coercible::Symbol.enum(:collection, :item)
+
+    ContributablesKey = Coercible::Symbol.enum(:collections, :items)
+
+    Contribution = ModelInstance("CollectionContribution") | ModelInstance("ItemContribution")
+
+    ContributionKlassName = Coercible::String.enum("CollectionContribution", "ItemContribution")
+
+    Contributor = ModelInstance("Contributor")
+
+    Role = ModelInstance("ControlledVocabularyItem")
+  end
+end

--- a/app/services/contributors/types.rb
+++ b/app/services/contributors/types.rb
@@ -4,7 +4,7 @@ module Contributors
   module Types
     include Dry.Types
 
-    extend Shared::EnhancedTypes
+    extend Support::EnhancedTypes
 
     ORCID_FORMAT = %r,\Ahttps://orcid.org/(?<identifier>\d{4}(?:-\d{4}){3})\z,
 

--- a/app/services/controlled_vocabularies/persistence/item_persistor.rb
+++ b/app/services/controlled_vocabularies/persistence/item_persistor.rb
@@ -44,6 +44,8 @@ module ControlledVocabularies
 
         @controlled_vocabulary_item.assign_attributes(parent:, position:)
 
+        @controlled_vocabulary_item.skip_rerank = true
+
         yield monadic_save controlled_vocabulary_item
 
         item_identifiers << item.identifier

--- a/app/services/controlled_vocabularies/persistence/persistor.rb
+++ b/app/services/controlled_vocabularies/persistence/persistor.rb
@@ -74,13 +74,16 @@ module ControlledVocabularies
 
         @items_count = item_identifiers.size
         @item_identifiers = item_identifiers.to_a
-        @item_set = controlled_vocabulary.calculate_item_set!
 
         super
       end
 
       wrapped_hook! def clean_up
         controlled_vocabulary.controlled_vocabulary_items.where.not(identifier: item_identifiers).destroy_all
+
+        @item_set = controlled_vocabulary.calculate_item_set!
+
+        yield controlled_vocabulary.rerank_items
 
         controlled_vocabulary.update_columns(item_identifiers:, item_set:, items_count:)
 

--- a/app/services/controlled_vocabularies/transient/item.rb
+++ b/app/services/controlled_vocabularies/transient/item.rb
@@ -3,14 +3,17 @@
 module ControlledVocabularies
   module Transient
     class Item < Support::FlexibleStruct
+      include Dry::Core::Constants
       include Support::Typing
 
       attribute :identifier, Types::Identifier
       attribute :label, Types::Label
 
-      attribute? :children, Types::Array.of(self).default { [] }
+      attribute? :children, Types::Array.of(self).default(EMPTY_ARRAY)
       attribute? :description, Types::Description
       attribute? :unselectable, Types::Bool.default(false)
+      attribute? :priority, Types::Priority
+      attribute? :tags, Types::Tags
       attribute? :url, Types::URL
 
       def finding
@@ -18,7 +21,7 @@ module ControlledVocabularies
       end
 
       def to_update
-        { label:, description:, unselectable:, url:, }
+        { label:, description:, priority:, tags:, unselectable:, url:, }
       end
     end
   end

--- a/app/services/controlled_vocabularies/type_registry.rb
+++ b/app/services/controlled_vocabularies/type_registry.rb
@@ -8,7 +8,9 @@ module ControlledVocabularies
     tc.add! :label, Types::Label
     tc.add! :namespace, Types::Namespace
     tc.add! :name, Types::Name
+    tc.add! :priority, Types::Priority
     tc.add! :provides, Types::Provides
+    tc.add! :tags, Types::Tags
     tc.add! :url, Types::URL
     tc.add! :version, Types::Version
   end

--- a/app/services/controlled_vocabularies/types.rb
+++ b/app/services/controlled_vocabularies/types.rb
@@ -3,6 +3,7 @@
 module ControlledVocabularies
   module Types
     include Dry.Types
+    include Dry::Core::Constants
 
     extend Support::EnhancedTypes
 
@@ -21,6 +22,12 @@ module ControlledVocabularies
     Label = Name
 
     Description = String.optional
+
+    Priority = Integer.default(0).fallback(0)
+
+    Tag = Coercible::String.constructor { _1.to_s.strip }.constrained(filled: true, rails_present: true)
+
+    Tags = Coercible::Array.of(Tag).default(EMPTY_ARRAY).fallback(EMPTY_ARRAY)
 
     URL = String.constrained(format: /\A#{Support::GlobalTypes::URL_PATTERN}\z/)
 

--- a/app/services/shared/type_registry.rb
+++ b/app/services/shared/type_registry.rb
@@ -8,6 +8,7 @@ module Shared
     tc.add_model! "Collection"
     tc.add_model! "Community"
     tc.add_model! "ControlledVocabulary"
+    tc.add_model! "ControlledVocabularyItem"
     tc.add_model! "ControlledVocabularySource"
     tc.add_model! "Item"
     tc.add_model! "SchemaDefinition"

--- a/config/initializers/900_good_job.rb
+++ b/config/initializers/900_good_job.rb
@@ -22,6 +22,16 @@ Rails.application.configure do
   config.good_job.shutdown_timeout = 25 # seconds
   config.good_job.enable_cron = true
   config.good_job.cron = {
+    "attributions.collections.manage": {
+      cron: "*/10 * * * *",
+      class: "Attributions::Collections::ManageJob",
+      description: "Ensure collection attributions are up to date",
+    },
+    "attributions.items.manage": {
+      cron: "*/10 * * * *",
+      class: "Attributions::Items::ManageJob",
+      description: "Ensure item attributions are up to date",
+    },
     "contributors.audit_contribution_counts": {
       cron: "*/5 * * * *",
       class: "Contributors::AuditContributionCountsJob",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
       limited_visibility_requires_range: "must have a range set when visibility is limited"
       linked_to_parent: "cannot be linked to its parent"
       linked_to_itself: "cannot be linked to itself"
+      mismatched_vocabulary_item: "is not a part of the provided vocabulary"
       must_be_associated_with_entity: "must be associated with the provided entity"
       must_be_email: "must be an email"
       must_be_entity: "must be an entity"

--- a/db/migrate/20250114203526_improve_controlled_vocabulary_items.rb
+++ b/db/migrate/20250114203526_improve_controlled_vocabulary_items.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ImproveControlledVocabularyItems < ActiveRecord::Migration[7.0]
+  def change
+    change_table :controlled_vocabulary_items do |t|
+      t.bigint :priority, null: false, default: 0
+      t.bigint :ranking, null: true
+
+      t.citext :tags, null: false, array: true, default: []
+
+      t.index %i[priority position identifier], order: { priority: "DESC", position: :asc, identifier: :asc }, name: "index_controlled_vocabulary_items_sort_order"
+      t.index %i[parent_id ranking position], name: "index_controlled_vocabulary_items_ranking"
+      t.index :tags, using: :gin
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute(<<~SQL)
+        UPDATE controlled_vocabulary_items SET priority = 10000, tags = ARRAY['author'] WHERE identifier = 'aut';
+        UPDATE controlled_vocabulary_items SET priority = 9000, tags = ARRAY['editor'] WHERE identifier = 'edt';
+        UPDATE controlled_vocabulary_items SET priority = 8500, tags = ARRAY['translator'] WHERE identifier = 'trl';
+        UPDATE controlled_vocabulary_items SET tags = ARRAY['affiliated_institution'] WHERE identifier = 'his';
+        UPDATE controlled_vocabulary_items SET tags = ARRAY['contributor', 'default'] WHERE identifier = 'ctb';
+        UPDATE controlled_vocabulary_items SET tags = ARRAY['advisor'] WHERE identifier = 'ths';
+        UPDATE controlled_vocabulary_items SET priority = -10000, tags = ARRAY['other'] WHERE identifier = 'oth';
+        SQL
+
+        say_with_time "Calculate ranking for all items" do
+          exec_update(<<~SQL.strip_heredoc)
+          WITH rankings AS (
+            SELECT
+              id,
+              dense_rank() OVER w AS ranking
+              FROM controlled_vocabulary_items
+              WINDOW w AS (
+                PARTITION BY controlled_vocabulary_id, parent_id
+                ORDER BY priority DESC NULLS LAST, position ASC, identifier ASC
+              )
+          )
+          UPDATE controlled_vocabulary_items SET ranking = rankings.ranking
+          FROM rankings WHERE rankings.id = controlled_vocabulary_items.id;
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250114204050_create_contribution_role_configurations.rb
+++ b/db/migrate/20250114204050_create_contribution_role_configurations.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class CreateContributionRoleConfigurations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contribution_role_configurations, id: :uuid do |t|
+      t.references :controlled_vocabulary, null: false, foreign_key: { on_delete: :restrict }, type: :uuid, index: { name: "index_contribution_role_configurations_vocabulary" }
+      t.references :default_item, null: false, foreign_key: { to_table: :controlled_vocabulary_items, on_delete: :restrict }, type: :uuid
+      t.references :other_item, null: true, foreign_key: { to_table: :controlled_vocabulary_items, on_delete: :restrict }, type: :uuid
+      t.references :source, polymorphic: true, null: false, type: :uuid, index: { unique: true }
+
+      t.timestamps null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    reversible do |dir|
+      dir.up do
+        say_with_time "Ensuring a bare minimum MARC Relators contribution role" do
+          exec_update(<<~SQL)
+          INSERT INTO controlled_vocabularies (namespace, identifier, "version", provides, name)
+          VALUES ('meru.host', 'marc_codes', '1.0.0', 'contribution_roles', 'MARC Relator Codes')
+          ON CONFLICT DO NOTHING;
+          SQL
+        end
+
+        say_with_time "Ensuring bare minimum MARC Relators items exist" do
+          exec_update(<<~SQL)
+          WITH default_vocab AS (
+            SELECT "controlled_vocabularies"."id" AS controlled_vocabulary_id
+            FROM "controlled_vocabularies"
+            WHERE
+              "controlled_vocabularies"."namespace" = 'meru.host'
+              AND
+              "controlled_vocabularies"."identifier" = 'marc_codes'
+              AND
+              "controlled_vocabularies"."version" = '1.0.0'
+            LIMIT 1
+          ), items AS (
+            SELECT
+              default_vocab.controlled_vocabulary_id, t.*
+              FROM default_vocab
+              CROSS JOIN (
+                VALUES
+                ('aut', 'Author', 10000, ARRAY['author']),
+                ('edt', 'Editor', 9000, ARRAY['editor']),
+                ('trl', 'Translator', 8500, ARRAY['translator']),
+                ('ctb', 'Contributor', 0, ARRAY['contributor', 'default']),
+                ('his', 'Host institution', 0, ARRAY['affiliated_institution']),
+                ('ths', 'Thesis advisor', 0, ARRAY['advisor']),
+                ('oth', 'Other', -10000, ARRAY['other'])
+              ) AS t(identifier, label, priority, tags)
+          )
+          INSERT INTO controlled_vocabulary_items (controlled_vocabulary_id, identifier, label, priority, tags)
+          SELECT controlled_vocabulary_id, identifier, label, priority, tags FROM items
+          ON CONFLICT (controlled_vocabulary_id, identifier) DO NOTHING;
+          SQL
+        end
+
+        say_with_time "Populate initial contribution role configurations" do
+          exec_update(<<~SQL)
+          WITH default_vocab AS (
+            SELECT "controlled_vocabularies"."id" AS controlled_vocabulary_id
+            FROM "controlled_vocabularies"
+            WHERE
+              "controlled_vocabularies"."namespace" = 'meru.host'
+              AND
+              "controlled_vocabularies"."identifier" = 'marc_codes'
+              AND
+              "controlled_vocabularies"."version" = '1.0.0'
+            LIMIT 1
+          ), default_item AS (
+            SELECT "controlled_vocabulary_items"."id" AS default_item_id
+            FROM "controlled_vocabulary_items"
+            INNER JOIN default_vocab USING (controlled_vocabulary_id)
+            WHERE
+              "controlled_vocabulary_items"."identifier" = 'ctb'
+            LIMIT 1
+          ), other_item AS (
+            SELECT "controlled_vocabulary_items"."id" AS other_item_id
+            FROM "controlled_vocabulary_items"
+            INNER JOIN default_vocab USING (controlled_vocabulary_id)
+            WHERE
+              "controlled_vocabulary_items"."identifier" = 'oth'
+            LIMIT 1
+          ), gc AS (
+            INSERT INTO global_configurations (guard)
+            SELECT true
+            ON CONFLICT DO NOTHING
+          ), sources AS (
+            SELECT id AS source_id, 'GlobalConfiguration' AS source_type FROM global_configurations
+          ), configs AS (
+            SELECT DISTINCT ON (source_id)
+            controlled_vocabulary_id, default_item_id, other_item_id, source_id, source_type
+            FROM sources
+            CROSS JOIN default_vocab
+            CROSS JOIN default_item
+            CROSS JOIN other_item
+          )
+          INSERT INTO contribution_role_configurations (controlled_vocabulary_id, default_item_id, other_item_id, source_id, source_type)
+          SELECT controlled_vocabulary_id, default_item_id, other_item_id, source_id, source_type FROM configs;
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250114204917_control_contributions.rb
+++ b/db/migrate/20250114204917_control_contributions.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class ControlContributions < ActiveRecord::Migration[7.0]
+  TABLE_PAIRS = {
+    collection_contributions: :collection,
+    item_contributions: :item,
+  }.freeze
+
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+        DROP INDEX IF EXISTS index_item_contributions_uniqueness;
+        DROP INDEX IF EXISTS index_collection_contributions_uniqueness;
+        SQL
+      end
+    end
+
+    TABLE_PAIRS.each do |table_name, prefix|
+      change_table table_name do |t|
+        t.references :role, type: :uuid, null: true, foreign_key: { to_table: :controlled_vocabulary_items, on_delete: :restrict }
+
+        t.bigint :position
+
+        t.index %I[contributor_id #{prefix}_id role_id], name: "index_#{table_name}_assigned_uniqueness", unique: true
+      end
+
+      reversible do |dir|
+        dir.up do
+          say_with_time "Migrating contribution roles by tags" do
+            exec_update(<<~SQL)
+            WITH vocab AS (
+              SELECT controlled_vocabulary_id FROM contribution_role_configurations WHERE source_type = 'GlobalConfiguration' LIMIT 1
+            ), roles AS (
+              SELECT DISTINCT kind::citext AS role FROM #{table_name} WHERE kind IS NOT NULL AND kind ~ '[^[:space:]]+'
+            ), items AS (
+              SELECT DISTINCT ON (role)
+                role,
+                cvi.id AS role_id
+                FROM roles
+                CROSS JOIN vocab
+                INNER JOIN controlled_vocabulary_items cvi USING (controlled_vocabulary_id)
+                WHERE role = ANY(cvi.tags)
+            )
+            UPDATE #{table_name} AS c SET role_id = items.role_id
+            FROM items WHERE c.kind = items.role
+            SQL
+          end
+
+          say_with_time "Filling in default contribution role for other contributions" do
+            exec_update(<<~SQL)
+            WITH default_item AS (
+              SELECT default_item_id AS role_id FROM contribution_role_configurations WHERE source_type = 'GlobalConfiguration' LIMIT 1
+            )
+            UPDATE #{table_name} AS c SET role_id = default_item.role_id
+            FROM default_item WHERE c.role_id IS NULL
+            SQL
+          end
+        end
+      end
+
+      change_column_null table_name, :role_id, false
+    end
+  end
+end

--- a/db/migrate/20250117193735_create_collection_attributions.rb
+++ b/db/migrate/20250117193735_create_collection_attributions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class CreateCollectionAttributions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :collection_attributions, id: :uuid do |t|
+      t.references :collection, type: :uuid, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.references :contributor, type: :uuid, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.bigint :position, null: false
+
+      t.timestamps null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+      t.index %i[collection_id contributor_id], unique: true, name: "index_collection_attributions_uniqueness"
+      t.index %i[collection_id position], name: "index_collection_attributions_ordering"
+    end
+
+    reversible do |dir|
+      dir.up do
+        say_with_time "Populating initial collection attributions" do
+          exec_update(<<~SQL.strip_heredoc)
+          WITH attributed AS (
+            SELECT DISTINCT ON (cont.collection_id, cont.contributor_id)
+              cont.collection_id,
+              cont.contributor_id,
+              dense_rank() OVER w AS position
+            FROM collection_contributions cont
+            INNER JOIN controlled_vocabulary_items cvi ON cvi.id = cont.role_id
+            INNER JOIN contributors cbtr ON cbtr.id = cont.contributor_id
+            WINDOW w AS (
+              PARTITION BY cont.collection_id
+              ORDER BY cvi.priority DESC NULLS LAST, cvi.position ASC, cvi.identifier ASC, cont.position ASC NULLS LAST, cbtr.sort_name ASC
+            )
+          )
+          INSERT INTO collection_attributions (collection_id, contributor_id, position, created_at, updated_at)
+          SELECT collection_id, contributor_id, position, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+          FROM attributed
+          ON CONFLICT (collection_id, contributor_id) DO UPDATE SET
+            position = EXCLUDED.position,
+            updated_at =
+              CASE
+              WHEN collection_attributions.position IS DISTINCT FROM EXCLUDED.position
+              THEN excluded.updated_at
+              ELSE collection_attributions.updated_at
+              END
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250117193744_create_item_attributions.rb
+++ b/db/migrate/20250117193744_create_item_attributions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class CreateItemAttributions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :item_attributions, id: :uuid do |t|
+      t.references :item, type: :uuid, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.references :contributor, type: :uuid, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.bigint :position, null: false
+
+      t.timestamps null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+      t.index %i[item_id contributor_id], unique: true, name: "index_item_attributions_uniqueness"
+      t.index %i[item_id position], name: "index_item_attributions_ordering"
+    end
+
+    reversible do |dir|
+      dir.up do
+        say_with_time "Populating initial item attributions" do
+          exec_update(<<~SQL.strip_heredoc)
+          WITH attributed AS (
+            SELECT DISTINCT ON (cont.item_id, cont.contributor_id)
+              cont.item_id,
+              cont.contributor_id,
+              dense_rank() OVER w AS position
+            FROM item_contributions cont
+            INNER JOIN controlled_vocabulary_items cvi ON cvi.id = cont.role_id
+            INNER JOIN contributors cbtr ON cbtr.id = cont.contributor_id
+            WINDOW w AS (
+              PARTITION BY cont.item_id
+              ORDER BY cvi.priority DESC NULLS LAST, cvi.position ASC, cvi.identifier ASC, cont.position ASC NULLS LAST, cbtr.sort_name ASC
+            )
+          )
+          INSERT INTO item_attributions (item_id, contributor_id, position, created_at, updated_at)
+          SELECT item_id, contributor_id, position, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+          FROM attributed
+          ON CONFLICT (item_id, contributor_id) DO UPDATE SET
+            position = EXCLUDED.position,
+            updated_at =
+              CASE
+              WHEN item_attributions.position IS DISTINCT FROM EXCLUDED.position
+              THEN excluded.updated_at
+              ELSE item_attributions.updated_at
+              END
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/lib/controlled_vocabularies/meru.host/marc_codes/1.0.0.json
+++ b/lib/controlled_vocabularies/meru.host/marc_codes/1.0.0.json
@@ -126,7 +126,7 @@
       "identifier": "aut",
       "description": "A person, family, or organization responsible for creating a work that is primarily textual in content, regardless of media type (e.g., printed text, spoken word, electronic text, tactile text) or genre (e.g., poems, novels, screenplays, blogs). Use also for persons, etc., creating a new work by paraphrasing, rewriting, or adapting works by another creator such that the modification has substantially changed the nature and content of the original or changed the medium of expression.",
       "priority": 10000,
-      "include_in_feed": true
+      "tags": ["author"]
     },
     {
       "label": "Author in quotations or text abstracts",
@@ -341,7 +341,8 @@
     {
       "label": "Contributor",
       "identifier": "ctb",
-      "description": "A person, family or organization responsible for making contributions to the resource. This includes those whose work has been contributed to a larger work, such as an anthology, serial publication, or other compilation of individual works. If a more specific role is available, prefer that, e.g. editor, compiler, illustrator."
+      "description": "A person, family or organization responsible for making contributions to the resource. This includes those whose work has been contributed to a larger work, such as an anthology, serial publication, or other compilation of individual works. If a more specific role is available, prefer that, e.g. editor, compiler, illustrator.",
+      "tags": ["contributor", "default"]
     },
     {
       "label": "Copyright claimant",
@@ -503,7 +504,7 @@
       "identifier": "edt",
       "description": "A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author.",
       "priority": 9000,
-      "include_in_feed": true
+      "tags": ["editor"]
     },
     {
       "label": "Editor of compilation",
@@ -638,7 +639,8 @@
     {
       "label": "Host institution",
       "identifier": "his",
-      "description": "An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
+      "description": "An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource.",
+      "tags": ["affiliated_institution"]
     },
     {
       "label": "Illuminator",
@@ -868,7 +870,9 @@
     {
       "label": "Other",
       "identifier": "oth",
-      "description": "A role that has no equivalent in the MARC list."
+      "description": "A role that has no equivalent in the MARC list.",
+      "priority": -10000,
+      "tags": ["other"]
     },
     {
       "label": "Owner",
@@ -1288,7 +1292,8 @@
     {
       "label": "Thesis advisor",
       "identifier": "ths",
-      "description": "A person under whose supervision a degree candidate develops and presents a thesis, mémoire, or text of a dissertation."
+      "description": "A person under whose supervision a degree candidate develops and presents a thesis, mémoire, or text of a dissertation.",
+      "tags": ["advisor"]
     },
     {
       "label": "Transcriber",
@@ -1299,8 +1304,8 @@
       "label": "Translator",
       "identifier": "trl",
       "description": "A person or organization who renders a text from one language into another, or from an older form of a language into the modern form.",
-      "include_in_feed": true,
-      "priority": 8500
+      "priority": 8500,
+      "tags": ["translator"]
     },
     {
       "label": "Type designer",

--- a/lib/frozen_record/static_cached_columns.yml
+++ b/lib/frozen_record/static_cached_columns.yml
@@ -1743,6 +1743,87 @@
   default_function: 
   has_default: false
   virtual: false
+- id: CollectionAttribution#id
+  model_name: CollectionAttribution
+  table_name: collection_attributions
+  name: id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: gen_random_uuid()
+  has_default: true
+  virtual: false
+- id: CollectionAttribution#collection_id
+  model_name: CollectionAttribution
+  table_name: collection_attributions
+  name: collection_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: CollectionAttribution#contributor_id
+  model_name: CollectionAttribution
+  table_name: collection_attributions
+  name: contributor_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: CollectionAttribution#position
+  model_name: CollectionAttribution
+  table_name: collection_attributions
+  name: position
+  type: integer
+  'null': false
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: CollectionAttribution#created_at
+  model_name: CollectionAttribution
+  table_name: collection_attributions
+  name: created_at
+  type: datetime
+  'null': false
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
+- id: CollectionAttribution#updated_at
+  model_name: CollectionAttribution
+  table_name: collection_attributions
+  name: updated_at
+  type: datetime
+  'null': false
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
 - id: CollectionAuthorization#community_id
   model_name: CollectionAuthorization
   table_name: collection_authorizations
@@ -1874,6 +1955,33 @@
   default: 
   default_function: CURRENT_TIMESTAMP
   has_default: true
+  virtual: false
+- id: CollectionContribution#role_id
+  model_name: CollectionContribution
+  table_name: collection_contributions
+  name: role_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: CollectionContribution#position
+  model_name: CollectionContribution
+  table_name: collection_contributions
+  name: position
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
   virtual: false
 - id: CollectionHierarchy#ancestor_id
   model_name: CollectionHierarchy
@@ -2689,6 +2797,112 @@
   default_function: 
   has_default: false
   virtual: false
+- id: ContributionRoleConfiguration#id
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: gen_random_uuid()
+  has_default: true
+  virtual: false
+- id: ContributionRoleConfiguration#controlled_vocabulary_id
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: controlled_vocabulary_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ContributionRoleConfiguration#default_item_id
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: default_item_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ContributionRoleConfiguration#other_item_id
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: other_item_id
+  type: uuid
+  'null': true
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ContributionRoleConfiguration#source_type
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: source_type
+  type: string
+  'null': false
+  sql_type_metadata:
+    sql_type: character varying
+    type: string
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ContributionRoleConfiguration#source_id
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: source_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ContributionRoleConfiguration#created_at
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: created_at
+  type: datetime
+  'null': false
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
+- id: ContributionRoleConfiguration#updated_at
+  model_name: ContributionRoleConfiguration
+  table_name: contribution_role_configurations
+  name: updated_at
+  type: datetime
+  'null': false
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
 - id: Contributor#id
   model_name: Contributor
   table_name: contributors
@@ -3271,6 +3485,47 @@
     precision: 6
   default: 
   default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
+- id: ControlledVocabularyItem#priority
+  model_name: ControlledVocabularyItem
+  table_name: controlled_vocabulary_items
+  name: priority
+  type: integer
+  'null': false
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: '0'
+  default_function: 
+  has_default: true
+  virtual: false
+- id: ControlledVocabularyItem#ranking
+  model_name: ControlledVocabularyItem
+  table_name: controlled_vocabulary_items
+  name: ranking
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ControlledVocabularyItem#tags
+  model_name: ControlledVocabularyItem
+  table_name: controlled_vocabulary_items
+  name: tags
+  type: citext
+  'null': false
+  sql_type_metadata:
+    sql_type: citext[]
+    type: citext
+  default: "{}"
+  default_function: 
   has_default: true
   virtual: false
 - id: ControlledVocabularyItemHierarchy#ancestor_id
@@ -8345,6 +8600,87 @@
   default_function: 
   has_default: false
   virtual: false
+- id: ItemAttribution#id
+  model_name: ItemAttribution
+  table_name: item_attributions
+  name: id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: gen_random_uuid()
+  has_default: true
+  virtual: false
+- id: ItemAttribution#item_id
+  model_name: ItemAttribution
+  table_name: item_attributions
+  name: item_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ItemAttribution#contributor_id
+  model_name: ItemAttribution
+  table_name: item_attributions
+  name: contributor_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ItemAttribution#position
+  model_name: ItemAttribution
+  table_name: item_attributions
+  name: position
+  type: integer
+  'null': false
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ItemAttribution#created_at
+  model_name: ItemAttribution
+  table_name: item_attributions
+  name: created_at
+  type: datetime
+  'null': false
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
+- id: ItemAttribution#updated_at
+  model_name: ItemAttribution
+  table_name: item_attributions
+  name: updated_at
+  type: datetime
+  'null': false
+  sql_type_metadata:
+    sql_type: timestamp(6) without time zone
+    type: datetime
+    precision: 6
+  default: 
+  default_function: CURRENT_TIMESTAMP
+  has_default: true
+  virtual: false
 - id: ItemAuthorization#community_id
   model_name: ItemAuthorization
   table_name: item_authorizations
@@ -8489,6 +8825,33 @@
   default: 
   default_function: CURRENT_TIMESTAMP
   has_default: true
+  virtual: false
+- id: ItemContribution#role_id
+  model_name: ItemContribution
+  table_name: item_contributions
+  name: role_id
+  type: uuid
+  'null': false
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default: 
+  default_function: 
+  has_default: false
+  virtual: false
+- id: ItemContribution#position
+  model_name: ItemContribution
+  table_name: item_contributions
+  name: position
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: bigint
+    type: integer
+    limit: 8
+  default: 
+  default_function: 
+  has_default: false
   virtual: false
 - id: ItemHierarchy#ancestor_id
   model_name: ItemHierarchy

--- a/lib/support/model_concerns/arel_helpers.rb
+++ b/lib/support/model_concerns/arel_helpers.rb
@@ -16,6 +16,12 @@ module ArelHelpers
 
   MANY_ARRAY = Support::ArelExt::Types::ManyArray
 
+  def arel_value_in_array(value, array)
+    any_array = arel_named_fn("ANY", arel_quote(array))
+
+    arel_quote(value).eq(any_array)
+  end
+
   def arel_text_contains(field, value)
     arel_table[field].matches("%#{escape_ilike_needle(value)}%")
   end

--- a/spec/factories/contribution_role_configurations.rb
+++ b/spec/factories/contribution_role_configurations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contribution_role_configuration do
+    controlled_vocabulary { nil }
+    controlled_vocabulary_item { nil }
+    source { nil }
+  end
+end

--- a/spec/factories/controlled_vocabulary_items.rb
+++ b/spec/factories/controlled_vocabulary_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :controlled_vocabulary_item do
+    association(:controlled_vocabulary)
+
+    identifier { Faker::Lorem.unique.sentence.parameterize }
+
+    label { identifier.titleize }
+  end
+end

--- a/spec/jobs/attributions/collections/manage_job_spec.rb
+++ b/spec/jobs/attributions/collections/manage_job_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Attributions::Collections::ManageJob, type: :job do
+  it_behaves_like "a void operation job", "attributions.collections.manage"
+end

--- a/spec/jobs/attributions/items/manage_job_spec.rb
+++ b/spec/jobs/attributions/items/manage_job_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Attributions::Items::ManageJob, type: :job do
+  it_behaves_like "a void operation job", "attributions.items.manage"
+end

--- a/spec/operations/contribution_roles/fetch_config_spec.rb
+++ b/spec/operations/contribution_roles/fetch_config_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe ContributionRoles::FetchConfig, type: :operation do
+  let_it_be(:global_configuration) { GlobalConfiguration.fetch }
+  let_it_be(:global_contribution_role_configuration) { global_configuration.contribution_role_configuration }
+
+  let_it_be(:specific_vocabulary) { FactoryBot.create :controlled_vocabulary }
+  let_it_be(:specific_item) { FactoryBot.create :controlled_vocabulary_item, controlled_vocabulary: specific_vocabulary }
+
+  let_it_be(:community, refind: true) { FactoryBot.create :community }
+
+  let_it_be(:collection, refind: true) { FactoryBot.create :collection, community: }
+
+  let_it_be(:item, refind: true) { FactoryBot.create :item, collection: }
+
+  def give_specific_configuration!(record)
+    config = record.build_contribution_role_configuration
+
+    config.controlled_vocabulary = specific_vocabulary
+    config.default_item = specific_item
+    config.save!
+  end
+
+  context "when fetching with no specifier" do
+    it "reads from global configuration by default" do
+      expect_calling.to succeed.with(global_contribution_role_configuration)
+    end
+  end
+
+  context "when fetching a configuration for an item" do
+    it "reads from global configuration by default" do
+      expect_calling_with(contributable: item).to succeed.with(global_contribution_role_configuration)
+    end
+
+    context "when its community has an override" do
+      before do
+        give_specific_configuration!(community)
+
+        item.reload
+      end
+
+      it "will inherit the decision" do
+        expect_calling_with(contributable: item).to succeed.with(community.reload_contribution_role_configuration)
+      end
+    end
+
+    context "when its schema version has an override" do
+      let_it_be(:item_schema, refind: true) { item.schema_version }
+
+      before do
+        give_specific_configuration!(item_schema)
+
+        item.reload
+      end
+
+      it "will inherit the decision" do
+        expect_calling_with(contributable: item).to succeed.with(item_schema.reload_contribution_role_configuration)
+      end
+    end
+  end
+end

--- a/spec/policies/contribution_role_configuration_policy_spec.rb
+++ b/spec/policies/contribution_role_configuration_policy_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe ContributionRoleConfigurationPolicy, type: :policy do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/graphql/mutations/update_contribution_spec.rb
+++ b/spec/requests/graphql/mutations/update_contribution_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Mutations::UpdateContribution, type: :request, graphql: :mutation
 
         ... on Contribution {
           role
+          roleLabel
+          title
         }
       }
 
@@ -25,11 +27,10 @@ RSpec.describe Mutations::UpdateContribution, type: :request, graphql: :mutation
 
   let(:contribution) { nil }
 
-  let!(:old_role) { "old role" }
-  let!(:new_role) { "new role" }
+  let(:test_title) { "test title" }
 
   let_mutation_input!(:contribution_id) { contribution.to_encoded_id }
-  let_mutation_input!(:role) { new_role }
+  let_mutation_input!(:metadata) { { title: test_title } }
 
   as_an_admin_user do
     shared_examples_for "updating" do
@@ -37,7 +38,10 @@ RSpec.describe Mutations::UpdateContribution, type: :request, graphql: :mutation
         gql.mutation :update_contribution do |m|
           m.prop :contribution do |con|
             con[:id] = contribution_id
-            con[:role] = new_role
+            con[:role] = be_present
+            con[:role_label] = be_present
+            con[:title] = test_title
+
             con.typename(contribution.model_name.to_s)
           end
         end
@@ -51,13 +55,13 @@ RSpec.describe Mutations::UpdateContribution, type: :request, graphql: :mutation
     end
 
     context "with a collection contribution" do
-      let!(:contribution) { FactoryBot.create :collection_contribution, role: old_role, contributor: }
+      let!(:contribution) { FactoryBot.create :collection_contribution, contributor: }
 
       include_examples "updating"
     end
 
     context "with an item" do
-      let!(:contribution) { FactoryBot.create :item_contribution, role: old_role, contributor: }
+      let!(:contribution) { FactoryBot.create :item_contribution, contributor: }
 
       include_examples "updating"
     end

--- a/spec/requests/graphql/mutations/upsert_contribution_spec.rb
+++ b/spec/requests/graphql/mutations/upsert_contribution_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Mutations::UpsertContribution, type: :request, graphql: :mutation
   }
   GRAPHQL
 
+  let_it_be(:vocabulary, refind: true) { FactoryBot.create :controlled_vocabulary }
+
+  let_it_be(:contribution_role, refind: true) { FactoryBot.create :controlled_vocabulary_item, controlled_vocabulary: vocabulary }
+
   let_it_be(:collection, refind: true) { FactoryBot.create :collection }
   let_it_be(:item, refind: true) { FactoryBot.create :item }
 
@@ -34,6 +38,8 @@ RSpec.describe Mutations::UpsertContribution, type: :request, graphql: :mutation
 
     let_mutation_input!(:contributable_id) { contributable&.to_encoded_id }
 
+    let_mutation_input!(:role_id) { contribution_role.to_encoded_id }
+
     let_mutation_input!(:role) { "test role" }
 
     shared_examples_for "upsertion" do
@@ -41,13 +47,6 @@ RSpec.describe Mutations::UpsertContribution, type: :request, graphql: :mutation
         expect_request! do |req|
           req.data! expected_shape
         end
-      end
-
-      it "is idempotent" do
-        expect do
-          make_default_request!
-          make_default_request!
-        end.to change(contributable.contributions_klass, :count).by(1)
       end
     end
 


### PR DESCRIPTION
* Allow multiple contributors per contributable
* Add ability to configure contributor role vocabularies at varying levels in the hierarchy in anticipation of harvesting improvements
* Add prioritization and tagging to controlled vocabularies
* Add attributions for ease-of-use to retrieve unique contributors per contributable