### PR TITLE
[B] Ensure contribution roles are actually assigned

### DIFF
--- a/app/graphql/mutations/upsert_contribution.rb
+++ b/app/graphql/mutations/upsert_contribution.rb
@@ -12,8 +12,9 @@ module Mutations
     argument :contributable_id, ID, loads: Types::ContributableType, required: true
     argument :contributor_id, ID, loads: Types::AnyContributorType, required: true
 
-    argument :role_id, ID, loads: Types::ControlledVocabularyItemType, required: false,
-      description: "If not provided, it will use the default role."
+    argument :role_id, ID, loads: Types::ControlledVocabularyItemType, required: false do
+      description "If not provided, it will use the default role."
+    end
 
     argument :role, String, as: :deprecated_role, required: false, transient: true, description: "An arbitrary text value that describes the kind of contribution",
       deprecation_reason: "No longer used"

--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -42,7 +42,7 @@ module Types
     # @yieldreturn [Boolean]
     # @return [<String>]
     def argument_paths_for_if(names: [], parent: nil, &block)
-      argument_name = [parent, name].compact.join(?.)
+      argument_name = [parent, keyword || name].compact.join(?.)
 
       names << argument_name if yield(self)
 
@@ -70,7 +70,7 @@ module Types
     # @return [<Symbol>]
     def transient_arguments(names: [], parent: nil)
       argument_paths_for_if(&:transient?).map do |arg|
-        arg.to_s.underscore.to_sym
+        arg.split(?.).map { _1.to_s.underscore }.join(?.).to_sym
       end
     end
 

--- a/app/operations/mutations/operations/upsert_contribution.rb
+++ b/app/operations/mutations/operations/upsert_contribution.rb
@@ -8,8 +8,6 @@ module Mutations
       def call(contributable:, contributor:, **inputs)
         authorize contributable, :update?
 
-        inputs.delete(:deprecated_role)
-
         result = contributable.attach_contribution(contributor, **inputs)
 
         with_attached_result! :contribution, result

--- a/spec/requests/graphql/mutations/upsert_contribution_spec.rb
+++ b/spec/requests/graphql/mutations/upsert_contribution_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Mutations::UpsertContribution, type: :request, graphql: :mutation
         ... on Contribution {
           contributorKind
           displayName
+
+          contributionRole {
+            id
+          }
         }
       }
 
@@ -61,6 +65,10 @@ RSpec.describe Mutations::UpsertContribution, type: :request, graphql: :mutation
             c[:id] = be_an_encoded_id
             c[:contributor_kind] = "person"
             c[:display_name] = contributor.display_name
+
+            c.prop :contribution_role do |cr|
+              cr[:id] = role_id
+            end
           end
         end
       end
@@ -79,6 +87,10 @@ RSpec.describe Mutations::UpsertContribution, type: :request, graphql: :mutation
             c[:id] = be_an_encoded_id
             c[:contributor_kind] = "person"
             c[:display_name] = contributor.display_name
+
+            c.prop :contribution_role do |cr|
+              cr[:id] = role_id
+            end
           end
         end
       end


### PR DESCRIPTION
Fix transient argument derivation when the name of the argument has been reassigned.