### PR TITLE
[B] Address issues with ancestor sorting

### DIFF
--- a/app/operations/schemas/orderings/refresh.rb
+++ b/app/operations/schemas/orderings/refresh.rb
@@ -23,7 +23,7 @@ module Schemas
       SQL
 
       PREFIX = <<~SQL.squish
-      INSERT INTO ordering_entries (ordering_id, entity_id, entity_type, position, inverse_position, link_operator, auth_path, scope, relative_depth, tree_depth, tree_parent_id, tree_parent_type)
+      INSERT INTO ordering_entries (ordering_id, entity_id, entity_type, position, inverse_position, link_operator, auth_path, scope, relative_depth, order_props, tree_depth, tree_parent_id, tree_parent_type)
       SQL
 
       SUFFIX = <<~SQL.squish
@@ -35,6 +35,7 @@ module Schemas
         auth_path = EXCLUDED.auth_path,
         scope = EXCLUDED.scope,
         relative_depth = EXCLUDED.relative_depth,
+        order_props = EXCLUDED.order_props,
         tree_depth = EXCLUDED.tree_depth,
         tree_parent_id = EXCLUDED.tree_parent_id,
         tree_parent_type = EXCLUDED.tree_parent_type,
@@ -50,6 +51,8 @@ module Schemas
           ordering_entries.scope IS DISTINCT FROM EXCLUDED.scope
           OR
           ordering_entries.relative_depth IS DISTINCT FROM EXCLUDED.relative_depth
+          OR
+          ordering_entries.order_props IS DISTINCT FROM EXCLUDED.order_props
           OR
           ordering_entries.tree_depth IS DISTINCT FROM EXCLUDED.tree_depth
           OR

--- a/app/services/schemas/orderings/order_builder.rb
+++ b/app/services/schemas/orderings/order_builder.rb
@@ -40,7 +40,7 @@ module Schemas
         (?:#{COMPONENT_FORMAT}+)
         (?:\.#{COMPONENT_FORMAT}+?)?
       )
-      (?<type>\##{Regexp.union(SUPPORTED_SCHEMA_PROPERTY_TYPES)})?
+      (?:\#(?<type>#{Regexp.union(SUPPORTED_SCHEMA_PROPERTY_TYPES)}))?
       \z/x
 
       ANCESTOR_PROPS_PATTERN = /\A
@@ -54,7 +54,7 @@ module Schemas
         (?:#{COMPONENT_FORMAT}+)
         (?:\.#{COMPONENT_FORMAT}+?)?
       )
-      (?<type>\##{Regexp.union(SUPPORTED_SCHEMA_PROPERTY_TYPES)})?
+      (?:\#(?<type>#{Regexp.union(SUPPORTED_SCHEMA_PROPERTY_TYPES)}))?
       \z/x
 
       PATTERN = Regexp.union(STATIC_PATTERN, ANCESTOR_STATIC_PATTERN, PROPS_PATTERN, ANCESTOR_PROPS_PATTERN)

--- a/app/services/schemas/orderings/order_expression.rb
+++ b/app/services/schemas/orderings/order_expression.rb
@@ -9,8 +9,14 @@ module Schemas
     class OrderExpression < Dry::Struct
       # @!attribute [r] joins
       # A mapping of join expressions that get attached to the {OrderingEntryCandidate.query_for candidate ordering process}.
-      # @return [Hash]
+      # @return [{ String => Arel::Nodes::Join }]
       attribute :joins, Types::ArelJoinMap
+
+      # @!attribute [r] props
+      # A mapping of the props used to calculate {#default_orderings} and {#inverse_orderings},
+      # for introspection.
+      # @return [{ String => Arel::Nodes::Node }]
+      attribute :props, Types::ArelPropsMap
 
       # @!attribute [r] default_orderings
       # @return [<Arel::Nodes::Ordering>]

--- a/app/services/schemas/orderings/types.rb
+++ b/app/services/schemas/orderings/types.rb
@@ -23,6 +23,8 @@ module Schemas
 
       ArelOrderings = Array.of(ArelOrdering)
 
+      ArelPropsMap = Hash.map(String, Instance(::Arel::Expressions))
+
       ColumnList = Coercible::Array.of(Coercible::Symbol).constrained(min_size: 1)
 
       Direction = ::Support::GlobalTypes::SimpleSortDirection

--- a/db/migrate/20250224203941_store_order_props_on_ordering_entry.rb
+++ b/db/migrate/20250224203941_store_order_props_on_ordering_entry.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class StoreOrderPropsOnOrderingEntry < ActiveRecord::Migration[7.0]
+  def change
+    change_table :ordering_entries do |t|
+      t.jsonb :order_props, null: false, default: {}
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5024,7 +5024,8 @@ CREATE TABLE public.ordering_entries (
     tree_parent_id uuid,
     stale_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    order_props jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -13151,6 +13152,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250218011515'),
 ('20250219225500'),
 ('20250219234712'),
-('20250220221139');
+('20250220221139'),
+('20250224203941');
 
 

--- a/lib/frozen_record/static_cached_columns.yml
+++ b/lib/frozen_record/static_cached_columns.yml
@@ -11673,6 +11673,19 @@
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
+- id: OrderingEntry#order_props
+  model_name: OrderingEntry
+  table_name: ordering_entries
+  name: order_props
+  type: jsonb
+  'null': false
+  sql_type_metadata:
+    sql_type: jsonb
+    type: jsonb
+  default: "{}"
+  default_function: 
+  has_default: true
+  virtual: false
 - id: OrderingEntryAncestorLink#id
   model_name: OrderingEntryAncestorLink
   table_name: ordering_entry_ancestor_links


### PR DESCRIPTION
* Properly detect type from order path
* Ensure correct join is used for reading ancestor prop
* Store order props on ordering entries to make it easier to glean exactly what was used to calculate the ordering for any future issues and introspection.