### PR TITLE
[E] Audit authorization and permissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -683,6 +683,10 @@ RSpec/RepeatedExample:
 RSpec/ScatteredLet:
   Enabled: false
 
+# False positives that don't understand other context building helpers.
+RSpec/ScatteredSetup:
+  Enabled: false
+
 RSpec/SkipBlockInsideExample:
   Enabled: true
 

--- a/app/graphql/types/abstract_model.rb
+++ b/app/graphql/types/abstract_model.rb
@@ -12,6 +12,28 @@ module Types
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
     class << self
+      # @param [ApplicationRecord] object
+      # @param [GraphQL::Query::Context] context
+      def authorized?(object, context)
+        if context[:current_object].kind_of?(::Types::MutationType)
+          # This is an object being loaded as an argument in a mutation.
+          # If we can't even read it, throw an exception that GQL will catch and skip the mutation entirely.
+          return pundit_authorize!(object, :read_for_mutation?, context)
+        end
+
+        pundit_authorized? object, :show?, context
+      rescue Pundit::NotDefinedError
+        # :nocov:
+        # In development or test, we want an error raised. In production
+        # environments, fall back to the old behavior of just implicitly
+        # allowing access in order to ensure we're not breaking anything
+        # that doesn't have a policy yet.
+        raise e if Rails.env.development? || Rails.env.test?
+
+        return true
+        # :nocov:
+      end
+
       def inherited(subclass)
         super if defined?(super)
 

--- a/app/graphql/types/entity_permission_filter_type.rb
+++ b/app/graphql/types/entity_permission_filter_type.rb
@@ -2,7 +2,29 @@
 
 module Types
   class EntityPermissionFilterType < Types::BaseEnum
-    value "READ_ONLY"
-    value "CRUD"
+    description <<~TEXT
+    When retrieving lists of entities, sometimes it is helpful to only show
+    entities that the current user (or related user) has access to.
+    TEXT
+
+    value "SKIP" do
+      description <<~TEXT
+      A default value that skips checking for access. It will retrieve every
+      entity visible to the current user.
+      TEXT
+    end
+
+    value "READ_ONLY" do
+      description <<~TEXT
+      Show only the entities that a user has specific read access for—this allows
+      them to view the full record as opposed to just what appears in the frontend.
+      TEXT
+    end
+
+    value "UPDATE" do
+      description <<~TEXT
+      Show entities that a user has the ability to update.
+      TEXT
+    end
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -42,6 +42,11 @@ class Asset < ApplicationRecord
 
   delegate :original_filename, to: :attachment, allow_nil: true
 
+  # Compatibility for {EntityChildRecordPolicy}
+  def entity
+    attachable
+  end
+
   # We mask this with {#download_url} in order to track analytics of a download.
   #
   # @return [String]

--- a/app/models/authorizing_entity.rb
+++ b/app/models/authorizing_entity.rb
@@ -10,4 +10,8 @@ class AuthorizingEntity < ApplicationRecord
   include TimestampScopes
 
   self.primary_key = %i[auth_path entity_id scope hierarchical_type hierarchical_id].freeze
+
+  belongs_to :entity, inverse_of: :authorizing_entities
+
+  belongs_to :hierarchical, polymorphic: true, inverse_of: :authorizing_entities
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -25,6 +25,8 @@ class Community < ApplicationRecord
 
   has_many :users, through: :community_memberships
 
+  scope :currently_visible, -> { all }
+
   validates :title, presence: true
 
   alias_attribute :name, :title
@@ -39,6 +41,10 @@ class Community < ApplicationRecord
   # @return [ActiveRecord::Relation<Contribution>] a null relation
   def contributions
     CollectionContribution.none
+  end
+
+  def currently_visible?
+    true
   end
 
   # @return [:community]

--- a/app/models/concerns/checks_contextual_permissions.rb
+++ b/app/models/concerns/checks_contextual_permissions.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Scopes and other helpers for checking on permissions for a {HierarchicalEntity},
+# {Entity}, or {EntityAdjacent}.
+#
+# @see ContextualSinglePermission
+module ChecksContextualPermissions
+  extend ActiveSupport::Concern
+
+  included do
+    extend Dry::Core::ClassAttributes
+
+    defines :contextual_permission_primary_key, type: Entities::Types::Symbol
+
+    contextual_permission_primary_key :_must_be_set
+  end
+
+  module ClassMethods
+    # @see .with_permitted_actions_for
+    # @see Resolvers::FiltersByEntityPermission#apply_access_with_read_only
+    # @note This is specifically for checking for permissions to read the entire entity,
+    #   not necessarily whether or not the entity can be shown in the FE, etc.
+    # @param [User] user
+    # @return [ActiveRecord::Relation<HierarchicalEntity>]
+    def readable_by(user)
+      # :nocov:
+      return all if user.try(:has_global_admin_access?)
+      # :nocov:
+
+      with_permitted_actions_for(user, "self.read")
+    end
+
+    # @see .with_permitted_actions_for
+    # @see Resolvers::FiltersByEntityPermission#apply_access_with_update
+    # @param [User] user
+    # @return [ActiveRecord::Relation<HierarchicalEntity>]
+    def updatable_by(user)
+      # :nocov:
+      return all if user.try(:has_global_admin_access?)
+      # :nocov:
+
+      with_permitted_actions_for(user, "self.update")
+    end
+
+    # @param [User] user
+    # @param [<String>] actions
+    # @return [ActiveRecord::Relation<HierarchicalEntity>]
+    def with_permitted_actions_for(user, *actions)
+      constraint = ContextualSinglePermission.for_hierarchical_type(model_name.to_s).with_permitted_actions_for(user, *actions).select(:hierarchical_id)
+
+      where(contextual_permission_primary_key => constraint)
+    end
+  end
+end

--- a/app/models/concerns/layout_definition.rb
+++ b/app/models/concerns/layout_definition.rb
@@ -21,6 +21,8 @@ module LayoutDefinition
 
     template_definition_names [].freeze
 
+    delegate :policy_class, to: :class
+
     scope :root, -> { where(entity_type: nil, entity_id: nil) }
     scope :leaf, -> { where(arel_table[:entity_type].not_eq(nil).and(arel_table[:entity_id].not_eq(nil))) }
 
@@ -58,6 +60,10 @@ module LayoutDefinition
   end
 
   module ClassMethods
+    def policy_class
+      LayoutDefinitionPolicy
+    end
+
     def template_kinds!(...)
       super
 

--- a/app/models/concerns/layout_instance.rb
+++ b/app/models/concerns/layout_instance.rb
@@ -23,6 +23,8 @@ module LayoutInstance
 
     scope :with_template_instances, -> { includes(*template_instance_names) }
 
+    delegate :policy_class, to: :class
+
     validates :generation, presence: true
 
     after_save :clear_template_instances!
@@ -100,6 +102,10 @@ module LayoutInstance
     # @return [ActiveRecord::Relation<LayoutInstance>]
     def limited_to_layout_definitions(*definitions)
       joins(:layout_definition).merge(layout_record.definition_klass.limited_to(*definitions))
+    end
+
+    def policy_class
+      LayoutInstancePolicy
     end
 
     def template_kinds!(...)

--- a/app/models/concerns/references_entity_visibility.rb
+++ b/app/models/concerns/references_entity_visibility.rb
@@ -24,7 +24,7 @@ module ReferencesEntityVisibility
       :currently_visible?,
       to: :actual_entity_visibility
 
-    scope :visible_at, ->(time) { joins(:entity_visibility).merge(EntityVisibility.visible_at(time)) }
+    scope :visible_at, ->(time) { left_outer_joins(:entity_visibility).merge(EntityVisibility.visible_at(time)) }
     scope :hidden_at, ->(time) { joins(:entity_visibility).merge(EntityVisibility.hidden_at(time)) }
 
     scope :currently_visible, -> { visible_at Time.current }

--- a/app/models/concerns/template_definition.rb
+++ b/app/models/concerns/template_definition.rb
@@ -20,6 +20,8 @@ module TemplateDefinition
       where.not(position: positions)
     end
 
+    delegate :policy_class, to: :class
+
     before_validation :infer_config!
   end
 
@@ -61,5 +63,11 @@ module TemplateDefinition
   # @return [void]
   def infer_config!
     self.config = build_config!
+  end
+
+  module ClassMethods
+    def policy_class
+      TemplateDefinitionPolicy
+    end
   end
 end

--- a/app/models/concerns/template_instance.rb
+++ b/app/models/concerns/template_instance.rb
@@ -16,6 +16,8 @@ module TemplateInstance
 
     has_one :instance_digest, as: :template_instance, class_name: "Templates::InstanceDigest", dependent: :destroy
 
+    delegate :policy_class, to: :class
+
     has_many_readonly :prev_siblings, -> { for_prev }, as: :template_instance, class_name: "Templates::InstanceSibling"
     has_many_readonly :next_siblings, -> { for_next }, as: :template_instance, class_name: "Templates::InstanceSibling"
 
@@ -106,5 +108,9 @@ module TemplateInstance
     self.config = build_config!
   end
 
-  module ClassMethods; end
+  module ClassMethods
+    def policy_class
+      TemplateInstancePolicy
+    end
+  end
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -6,6 +6,7 @@
 #
 # In future, it will also be used to insert linked entries into the hierarchy.
 class Entity < ApplicationRecord
+  include ChecksContextualPermissions
   include FiltersByEntityScope
   include FiltersBySchemaVersion
   include ScopesForHierarchical
@@ -18,13 +19,17 @@ class Entity < ApplicationRecord
 
   belongs_to :entity, polymorphic: true
   belongs_to :hierarchical, polymorphic: true
-  belongs_to :schema_version
+  belongs_to :schema_version, inverse_of: :entities
 
   has_one :schema_definition, through: :schema_version
+
+  contextual_permission_primary_key :entity_id
 
   CONTEXTUAL_TUPLE = %i[hierarchical_type hierarchical_id].freeze
 
   ENTITY_TUPLE = %i[entity_type entity_id].freeze
+
+  has_many :authorizing_entities, inverse_of: :entity, dependent: :delete_all
 
   has_many_readonly :contextual_permissions, primary_key: CONTEXTUAL_TUPLE, foreign_key: CONTEXTUAL_TUPLE
 

--- a/app/models/entity_link.rb
+++ b/app/models/entity_link.rb
@@ -9,6 +9,7 @@ class EntityLink < ApplicationRecord
   include HasSystemSlug
   include ManualListTarget
   include MatchesScopes
+  include ReferencesEntityVisibility
   include SyncsEntities
   include TimestampScopes
 
@@ -17,6 +18,8 @@ class EntityLink < ApplicationRecord
   belongs_to :source, polymorphic: true
   belongs_to :target, polymorphic: true
   belongs_to :schema_version, inverse_of: :entity_links
+
+  has_one_readonly :entity_visibility, primary_key: %i[target_type target_id], foreign_key: %i[entity_type entity_id]
 
   has_one :schema_definition, through: :schema_version
 

--- a/app/models/ordering_entry_candidate.rb
+++ b/app/models/ordering_entry_candidate.rb
@@ -9,6 +9,8 @@
 class OrderingEntryCandidate < ApplicationRecord
   include View
 
+  include EntityAdjacent
+
   belongs_to :entity, polymorphic: true
   belongs_to :schema_version
 

--- a/app/models/templates/manual_list_entry.rb
+++ b/app/models/templates/manual_list_entry.rb
@@ -4,6 +4,7 @@ module Templates
   # An individual entry in a {Templates::ManualList} for a given {Entity}.
   class ManualListEntry < ApplicationRecord
     include HasEphemeralSystemSlug
+    include ReferencesEntityVisibility
     include TimestampScopes
 
     pg_enum! :template_kind, as: :template_kind, allow_blank: false, suffix: :template
@@ -13,6 +14,8 @@ module Templates
 
     belongs_to :target, polymorphic: true,
       inverse_of: :incoming_manual_list_entries
+
+    has_one_readonly :entity_visibility, primary_key: %i[target_type target_id], foreign_key: %i[entity_type entity_id]
 
     scope :by_source, ->(source) { where(source:) }
     scope :by_target, ->(target) { where(target:) }

--- a/app/operations/entities/calculate_authorizing.rb
+++ b/app/operations/entities/calculate_authorizing.rb
@@ -40,9 +40,10 @@ module Entities
     SQL
 
     # @param [String, nil] auth_path
+    # @param [HierarchicalEntity] source
     # @param [Boolean] stale
     # @return [Dry::Monads::Success(Integer)]
-    def call(auth_path: nil, source: nil, stale: true)
+    def call(auth_path: nil, source: nil, stale: false)
       query = [PREFIX, generate_infix_for(auth_path:, source:, stale:), SUFFIX]
 
       inserted = sql_insert!(*query)
@@ -55,9 +56,10 @@ module Entities
     # Generate an infix to possibly fit between {PREFIX} and {SUFFIX}.
     #
     # @param [String] auth_path
+    # @param [HierarchicalEntity] source
     # @param [Boolean] stale
     # @return [String]
-    def generate_infix_for(auth_path: nil, source: nil, stale: true)
+    def generate_infix_for(auth_path: nil, source: nil, stale: false)
       if auth_path.present?
         with_sql_template(<<~SQL.squish, path: connection.quote(auth_path))
         WHERE ent.auth_path @> %<path>s OR ent.auth_path <@ %<path>s

--- a/app/operations/entities/reparent.rb
+++ b/app/operations/entities/reparent.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Entities
+  # @see Entities::Reparenter
+  class Reparent < Support::SimpleServiceOperation
+    service_klass Entities::Reparenter
+  end
+end

--- a/app/policies/abstract_harvest_policy.rb
+++ b/app/policies/abstract_harvest_policy.rb
@@ -2,6 +2,8 @@
 
 # @abstract
 class AbstractHarvestPolicy < ApplicationPolicy
+  readable_in_dev true
+
   class Scope < Scope
     def resolve
       if has_global_admin_access? || Rails.env.development?

--- a/app/policies/asset_policy.rb
+++ b/app/policies/asset_policy.rb
@@ -1,60 +1,6 @@
 # frozen_string_literal: true
 
-class AssetPolicy < ApplicationPolicy
-  def initialize(user, record)
-    super
-
-    @grid = grid_for user, record
-  end
-
-  def show?
-    has_admin_or_permission? :read
-  end
-
-  alias index? show?
-
-  def create?
-    has_admin_or_permission? :create
-  end
-
-  def update?
-    has_admin_or_permission? :update
-  end
-
-  def destroy?
-    has_admin_or_permission? :delete
-  end
-
-  def manage_access?
-    has_admin_or_permission? :manage_access
-  end
-
-  private
-
-  # @param [User, AnonymousUser] user
-  # @param [Asset] record
-  # @return [Roles::PermissionGrid]
-  def grid_for(user, record)
-    composed_role = ContextualPermission.fetch user, record.attachable
-
-    composed_role&.grid&.assets || Roles::EntityPermissionGrid.new.assets
-  end
-
-  # @param [#to_s] name
-  def has_admin_or_permission?(name)
-    return false if user.anonymous?
-
-    return true if user.has_global_admin_access?
-
-    has_grid? name
-  end
-
-  # @param [#to_s] name
-  # @see Roles::PermissionGrid#[]
-  def has_grid?(name)
-    @grid[name]
-  end
-
+class AssetPolicy < EntityChildRecordPolicy
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class CollectionPolicy < HierarchicalEntityPolicy
+  class Scope < Scope; end
 end

--- a/app/policies/entity_policy.rb
+++ b/app/policies/entity_policy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# @see Entity
+class EntityPolicy < EntityChildRecordPolicy
+  class Scope < Scope
+    def resolve
+      return scope.all if admin_or_has_allowed_action?("admin.access")
+
+      scope.currently_visible
+    end
+  end
+end

--- a/app/policies/hierarchical_entity_policy.rb
+++ b/app/policies/hierarchical_entity_policy.rb
@@ -124,11 +124,9 @@ class HierarchicalEntityPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if user.has_global_admin_access?
+      return scope.all if admin_or_has_allowed_action?("admin.access")
 
-      return scope.none if user.anonymous?
-
-      scope.with_permitted_actions_for(user, "self.read")
+      scope.currently_visible
     end
   end
 end

--- a/app/policies/item_policy.rb
+++ b/app/policies/item_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ItemPolicy < HierarchicalEntityPolicy
+  class Scope < Scope; end
 end

--- a/app/policies/layout_definition_policy.rb
+++ b/app/policies/layout_definition_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# @see LayoutDefinition
+class LayoutDefinitionPolicy < ApplicationPolicy
+  always_readable!
+
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/layout_instance_policy.rb
+++ b/app/policies/layout_instance_policy.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SchemaDefinitionPolicy < ApplicationPolicy
-  always_readable!
-
+class LayoutInstancePolicy < EntityChildRecordPolicy
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/ordering_policy.rb
+++ b/app/policies/ordering_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# @see Ordering
+class OrderingPolicy < EntityChildRecordPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/schema_version_policy.rb
+++ b/app/policies/schema_version_policy.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SchemaVersionPolicy < ApplicationPolicy
+  always_readable!
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/template_definition_policy.rb
+++ b/app/policies/template_definition_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# @see TemplateDefinition
+class TemplateDefinitionPolicy < ApplicationPolicy
+  always_readable!
+
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/template_instance_policy.rb
+++ b/app/policies/template_instance_policy.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SchemaDefinitionPolicy < ApplicationPolicy
-  always_readable!
-
+class TemplateInstancePolicy < EntityChildRecordPolicy
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/templates/instance_digest_policy.rb
+++ b/app/policies/templates/instance_digest_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Templates
+  # @see Templates::InstanceDigest
+  class InstanceDigestPolicy < ApplicationPolicy
+    always_readable!
+
+    class Scope < Scope
+      def resolve
+        scope.all
+      end
+    end
+  end
+end

--- a/app/policies/templates/instance_sibling_policy.rb
+++ b/app/policies/templates/instance_sibling_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Templates
+  # @see Templates::InstanceSibling
+  class InstanceSiblingPolicy < ApplicationPolicy
+    always_readable!
+
+    class Scope < Scope
+      def resolve
+        scope.all
+      end
+    end
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class UserPolicy < ApplicationPolicy
+  def read?
+    return true if record.anonymous? || record == user
+
+    super
+  end
+
   class Scope < Scope
     def resolve
       return scope.all if admin_or_has_allowed_action?("users.read")

--- a/app/services/anonymous_interface.rb
+++ b/app/services/anonymous_interface.rb
@@ -97,12 +97,20 @@ module AnonymousInterface
     "Anonymous User"
   end
 
+  def policy_class
+    ::UserPolicy
+  end
+
   # {AnonymousUser Anonymous users} are non-blank for purposes of object presence.
   #
   # @note Because of Naught's treatment of predicates, this would return `false`
   #   unless subsequently overridden.
   def present?
     true
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    AnonymousUser.empty_user.respond_to?(method_name, include_private) || super
   end
 
   # @see RelayNode::IdFromObject
@@ -135,6 +143,14 @@ module AnonymousInterface
     # @return [AnonymousUser]
     def find(*)
       new
+    end
+
+    def empty_user
+      @empty_user ||= User.new
+    end
+
+    def policy_class
+      ::UserPolicy
     end
   end
 end

--- a/app/services/entities/reparenter.rb
+++ b/app/services/entities/reparenter.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Entities
+  # A polymorphic service that is able to take two entities,
+  # a parent and a child, and reassign the child to belong to
+  # the parent.
+  #
+  # Validation of whether or not the parent can accept the child,
+  # beyond whether or not it is a valid edge, should happen at a
+  # higher level than this service.
+  #
+  # @see Schemas::Edges::Calculate
+  # @see Schemas::Edges::ChildAttributesBuilder
+  # @see Schemas::Edges::Edge
+  # @see Schemas::Instances::ReparentEntity
+  # @see Entities::Reparent
+  class Reparenter < Support::HookBased::Actor
+    include Dry::Initializer[undefined: false].define -> do
+      param :parent, Entities::Types::Entity
+      param :child, Entities::Types::Entity
+    end
+
+    include MeruAPI::Deps[
+      build_child_attributes: "schemas.edges.build_child_attributes",
+    ]
+
+    # @return [Hash]
+    attr_reader :attributes
+
+    # @return [HierarchicalEntity, nil]
+    attr_reader :old_parent
+
+    standard_execution!
+
+    after_execute :audit_authorizing!
+
+    # @return [Dry::Monads::Success(HierarchicalEntity)]
+    def call
+      run_callbacks :execute do
+        yield prepare!
+
+        yield assign_new_parent!
+      end
+
+      Success child
+    end
+
+    wrapped_hook! def prepare
+      @attributes = {}
+      @old_parent = child.hierarchical_parent
+
+      super
+    end
+
+    wrapped_hook! def assign_new_parent
+      @attributes = yield build_child_attributes.(parent, child)
+
+      child.assign_attributes attributes
+
+      # This should never fail under normal circumstances.
+      child.save!
+
+      super
+    end
+
+    private
+
+    # @return [void]
+    def audit_authorizing!
+      Entities::AuditAuthorizingJob.perform_later
+    end
+  end
+end

--- a/app/services/mutation_operations/base.rb
+++ b/app/services/mutation_operations/base.rb
@@ -115,10 +115,6 @@ module MutationOperations
     # @param [Object] value
     # @return [void]
     def attach!(key, value)
-      if graphql_response.key?(key) && value != graphql_response[key]
-        warn "already assigned value to graphql_response[#{key.inspect}]: #{graphql_response[key]}"
-      end
-
       graphql_response[key] = value
     end
 
@@ -220,11 +216,14 @@ module MutationOperations
 
         return model
       else
+        # :nocov:
         invalid_model! model
+        # :nocov:
       end
     end
 
     def upsert_model!(klass, attributes, unique_by:, attach_to: nil)
+      # :nocov:
       result = klass.upsert(attributes, returning: unique_by, unique_by:)
 
       conditions = unique_by.each_with_object({}) do |key, h|
@@ -236,26 +235,33 @@ module MutationOperations
       attach! attach_to, model if attach_to.present?
 
       return model
+      # :nocov:
     end
 
     def validate_model!(model, validation_context: nil)
+      # :nocov:
       if model.valid? validation_context
         model
       else
         invalid_model! model
       end
+      # :nocov:
     end
 
     def check_model!(model)
+      # :nocov:
       return model if model.errors.none?
 
       invalid_model! model
+      # :nocov:
     end
 
     def invalid_model!(model)
+      # :nocov:
       add_model_errors! model
 
       throw_invalid
+      # :nocov:
     end
 
     def destroy_model!(model, auth: false)
@@ -270,13 +276,16 @@ module MutationOperations
 
         graphql_response[:destroyed_id] = id
       else
+        # :nocov:
         invalid_model! model
+        # :nocov:
       end
     end
 
     # @param [#errors] model
     # @return [void]
     def add_model_errors!(model)
+      # :nocov:
       model.errors.each do |error|
         options = {}.tap do |h|
           h[:code] = error.type.to_s if error.type.kind_of?(Symbol)
@@ -285,6 +294,7 @@ module MutationOperations
 
         add_error! error.message, **options
       end
+      # :nocov:
     end
 
     # @!endgroup
@@ -341,8 +351,10 @@ module MutationOperations
           value
         end
 
-        m.failure do |failure|
+        m.failure do
+          # :nocov:
           something_went_wrong!(error_message:)
+          # :nocov:
         end
       end
     end
@@ -358,6 +370,7 @@ module MutationOperations
     end
 
     def with_operation_result!(result)
+      # :nocov:
       with_result!(result) do |m|
         m.success do |value|
           value
@@ -371,6 +384,7 @@ module MutationOperations
           end
         end
       end
+      # :nocov:
     end
 
     def with_attached_result!(key, result)
@@ -380,6 +394,7 @@ module MutationOperations
         end
 
         m.failure do |(code, reason)|
+          # :nocov:
           if reason.kind_of?(ApplicationRecord)
             invalid_model! reason
 
@@ -389,6 +404,7 @@ module MutationOperations
           message = reason.kind_of?(String) ? reason : "Something went wrong"
 
           add_error! message, code: code.to_s.presence
+          # :nocov:
         end
       end
     end

--- a/app/services/resolvers/abstract_resolver.rb
+++ b/app/services/resolvers/abstract_resolver.rb
@@ -29,6 +29,13 @@ module Resolvers
     # @return [User, AnonymousUser]
     attr_reader :current_user
 
+    # If the resolver's {#object} is a {User}, then this will be that.
+    # Otherwise, it will be {#current_user}.
+    #
+    # @see #from_user?
+    # @return [User, AnonymousUser]
+    attr_reader :relative_user
+
     delegate :has_admin_access?, to: :current_user, allow_nil: true
 
     def initialize(...)
@@ -37,6 +44,8 @@ module Resolvers
       reorder_search_params!
 
       @current_user = context&.[](:current_user) || AnonymousUser.new
+
+      @relative_user = from_user? ? object : current_user
     end
 
     def params=(params)
@@ -50,6 +59,13 @@ module Resolvers
     # @return [Integer]
     def count
       @count ||= fetch_count
+    end
+
+    # Whether this resolver is resolving from a user record.
+    #
+    # @see #relative_user
+    def from_user?
+      object.present? && object.kind_of?(User) || object.kind_of?(AnonymousUser)
     end
 
     # @return [ActiveRecord::Relation]

--- a/app/services/resolvers/collection_resolver.rb
+++ b/app/services/resolvers/collection_resolver.rb
@@ -2,7 +2,9 @@
 
 module Resolvers
   class CollectionResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
     include Resolvers::Treelike
 

--- a/app/services/resolvers/community_resolver.rb
+++ b/app/services/resolvers/community_resolver.rb
@@ -2,7 +2,9 @@
 
 module Resolvers
   class CommunityResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
 
     type Types::CommunityType.connection_type, null: false

--- a/app/services/resolvers/filters_by_entity_permission.rb
+++ b/app/services/resolvers/filters_by_entity_permission.rb
@@ -1,19 +1,29 @@
 # frozen_string_literal: true
 
 module Resolvers
+  # @see ::Types::EntityPermissionFilterType
   module FiltersByEntityPermission
     extend ActiveSupport::Concern
 
     included do
-      option :access, type: Types::EntityPermissionFilterType, default: "READ_ONLY"
+      option :access, type: ::Types::EntityPermissionFilterType, default: "SKIP", replace_null_with_default: true
     end
 
+    # @param [ActiveRecord::Relation<HierarchicalEntity>]
+    def apply_access_with_skip(scope)
+      scope.all
+    end
+
+    # @see HierarchicalEntity::ClassMethods#readable_by
+    # @param [ActiveRecord::Relation<HierarchicalEntity>]
     def apply_access_with_read_only(scope)
-      scope.with_permitted_actions_for(object, "self.read")
+      scope.readable_by(relative_user)
     end
 
-    def apply_access_with_crud(scope)
-      scope.with_permitted_actions_for(object, "self.read", "self.create", "self.update", "self.delete")
+    # @see HierarchicalEntity::ClassMethods#updatable_by
+    # @param [ActiveRecord::Relation<HierarchicalEntity>]
+    def apply_access_with_update(scope)
+      scope.updatable_by(relative_user)
     end
   end
 end

--- a/app/services/resolvers/item_resolver.rb
+++ b/app/services/resolvers/item_resolver.rb
@@ -2,7 +2,9 @@
 
 module Resolvers
   class ItemResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
     include Resolvers::Treelike
 

--- a/app/services/resolvers/related_collection_resolver.rb
+++ b/app/services/resolvers/related_collection_resolver.rb
@@ -3,7 +3,9 @@
 module Resolvers
   # @see RelatedCollectionLink
   class RelatedCollectionResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
 
     description "Retrieve linked collections of the same schema type"

--- a/app/services/resolvers/related_item_resolver.rb
+++ b/app/services/resolvers/related_item_resolver.rb
@@ -3,7 +3,9 @@
 module Resolvers
   # @see RelatedItemLink
   class RelatedItemResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
 
     description "Retrieve linked items of the same schema type"

--- a/app/services/resolvers/search_result_resolver.rb
+++ b/app/services/resolvers/search_result_resolver.rb
@@ -2,7 +2,9 @@
 
 module Resolvers
   class SearchResultResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::FiltersByEntityDescendantScope
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::FiltersBySchemaName
     include Resolvers::FinalizesResults
     include Resolvers::OrderedAsEntity

--- a/app/services/resolvers/single_subcollection_resolver.rb
+++ b/app/services/resolvers/single_subcollection_resolver.rb
@@ -3,6 +3,7 @@
 module Resolvers
   # A resolver for getting the first-matching {Collection} below a {Collection}.
   class SingleSubcollectionResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::FirstMatching
     include Resolvers::OrderedAsEntity
     include Resolvers::Subtreelike

--- a/app/services/resolvers/single_subitem_resolver.rb
+++ b/app/services/resolvers/single_subitem_resolver.rb
@@ -3,6 +3,7 @@
 module Resolvers
   # A resolver for getting the first-matching {Item} below a {Item}.
   class SingleSubitemResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::FirstMatching
     include Resolvers::OrderedAsEntity
     include Resolvers::Subtreelike

--- a/app/services/resolvers/subcollection_resolver.rb
+++ b/app/services/resolvers/subcollection_resolver.rb
@@ -3,7 +3,9 @@
 module Resolvers
   # A resolver for getting {Collection}s below a {Collection}.
   class SubcollectionResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
     include Resolvers::Subtreelike
 

--- a/app/services/resolvers/subitem_resolver.rb
+++ b/app/services/resolvers/subitem_resolver.rb
@@ -3,7 +3,9 @@
 module Resolvers
   # A resolver for getting {Item}s below an {Item}.
   class SubitemResolver < AbstractResolver
+    include Resolvers::Enhancements::AppliesPolicyScope
     include Resolvers::Enhancements::PageBasedPagination
+    include Resolvers::FiltersByEntityPermission
     include Resolvers::OrderedAsEntity
     include Resolvers::Subtreelike
 

--- a/app/services/roles/entity_permission_grid.rb
+++ b/app/services/roles/entity_permission_grid.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 module Roles
-  # @todo Actually stitch up the assets
   class EntityPermissionGrid < PermissionGrid
     permission :manage_access
 
-    grid :assets, default: true
+    grid :assets, default: false
   end
 end

--- a/app/services/schemas/orderings/dynamic_resolver.rb
+++ b/app/services/schemas/orderings/dynamic_resolver.rb
@@ -51,7 +51,7 @@ module Schemas
       end
 
       wrapped_hook! def resolve
-        entries = OrderingEntryCandidate.query_for(dynamic)
+        entries = OrderingEntryCandidate.currently_visible.query_for(dynamic)
 
         query = OrderingEntryCandidate
           .with(entries:)

--- a/app/services/templates/entity_lists/abstract_resolver.rb
+++ b/app/services/templates/entity_lists/abstract_resolver.rb
@@ -43,7 +43,9 @@ module Templates
       wrapped_hook! def resolve
         return super if source_entity.blank?
 
-        @entities = Array(resolve_entities.value_or(EMPTY_ARRAY)).compact.take(selection_limit)
+        resolved = Array(resolve_entities.value_or(EMPTY_ARRAY))
+
+        @entities = only_visible(resolved).take(selection_limit)
 
         super
       end
@@ -54,6 +56,14 @@ module Templates
         # :nocov:
         Success EMPTY_ARRAY
         # :nocov:
+      end
+
+      private
+
+      # @param [<HierarchicalEntity, nil>] entities
+      # @return [<HierarchicalEntity>]
+      def only_visible(entities)
+        entities.compact.select { _1.currently_visible? }
       end
 
       class << self

--- a/app/services/templates/entity_lists/manual_resolver.rb
+++ b/app/services/templates/entity_lists/manual_resolver.rb
@@ -9,7 +9,7 @@ module Templates
       def resolve_entities
         list_name = yield Maybe(manual_list_name)
 
-        Success source_entity.manual_list_entries.where(template_kind:, list_name:).limit(selection_limit).map(&:target)
+        Success source_entity.manual_list_entries.currently_visible.where(template_kind:, list_name:).limit(selection_limit).map(&:target)
       end
     end
   end

--- a/app/services/templates/entity_lists/named_resolver.rb
+++ b/app/services/templates/entity_lists/named_resolver.rb
@@ -9,7 +9,7 @@ module Templates
       def resolve_entities
         ordering = yield Maybe(source_entity.ordering(ordering_identifier))
 
-        entries_scope = ordering.ordering_entries.in_default_order.includes(:entity).limit(selection_limit)
+        entries_scope = ordering.ordering_entries.in_default_order.currently_visible.includes(:entity).limit(selection_limit)
 
         Success entries_scope.map(&:entity).compact
       end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -3,6 +3,12 @@
 RSpec.describe Community, type: :model do
   it_behaves_like "an entity with a reference"
 
+  let_it_be(:community, refind: true) { FactoryBot.create :community }
+
+  subject { community }
+
+  it { is_expected.to be_currently_visible }
+
   describe "#grant_system_roles!" do
     let!(:administrator) { FactoryBot.create :user, :admin }
 

--- a/spec/models/contextual_single_permission_spec.rb
+++ b/spec/models/contextual_single_permission_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe ContextualSinglePermission, type: :model do
-  let!(:role) { FactoryBot.create :role, :editor }
+  let_it_be(:role) { FactoryBot.create :role, :editor }
 
-  let!(:user) { FactoryBot.create :user }
+  let_it_be(:user) { FactoryBot.create :user }
 
-  let!(:community) { FactoryBot.create :community }
+  let_it_be(:community) { FactoryBot.create :community }
 
-  let!(:collection) { FactoryBot.create :collection, community: }
+  let_it_be(:collection, refind: true) { FactoryBot.create :collection, community: }
 
-  let!(:item) { FactoryBot.create :item, collection: }
+  let_it_be(:item, refind: true) { FactoryBot.create :item, collection: }
 
-  let!(:subitem) { FactoryBot.create :item, parent: item, collection: }
+  let_it_be(:subitem, refind: true) { FactoryBot.create :item, parent: item, collection: }
 
   let!(:accessible) { community }
 

--- a/spec/operations/entities/audit_authorizing_spec.rb
+++ b/spec/operations/entities/audit_authorizing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Entities::AuditAuthorizing, type: :operation do
 
       expect do
         operation.call
-      end.to change(AuthorizingEntity, :count).by(-1)
+      end.to change(AuthorizingEntity, :count).by(-2)
     end
   end
 end

--- a/spec/operations/entities/reparent_spec.rb
+++ b/spec/operations/entities/reparent_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Entities::Reparent, type: :operation, grants_access: true do
+  include ActiveJob::TestHelper
+
+  let_it_be(:manager_role) { FactoryBot.create :role, :manager }
+
+  let_it_be(:community, refind: true) { FactoryBot.create :community }
+  let_it_be(:other_community, refind: true) { FactoryBot.create :community }
+
+  let_it_be(:collection, refind: true) { FactoryBot.create :collection, community: community }
+  let_it_be(:item, refind: true) { FactoryBot.create :item, collection: }
+
+  let_it_be(:user, refind: true) { FactoryBot.create :user }
+
+  before do
+    grant_access! manager_role, on: community, to: user
+  end
+
+  it "will reparent and clean up inherited authorization logic" do
+    expect do
+      perform_enqueued_jobs do
+        expect_calling_with(other_community, collection).to succeed.with(collection)
+      end
+    end.to change { collection.reload.community_id }.from(community.id).to(other_community.id)
+      .and change { collection.reload.hierarchical_parent }.from(community).to(other_community)
+      .and change { Pundit.policy(user, collection.reload).update? }.from(true).to(false)
+      .and change { Pundit.policy(user, item.reload).update? }.from(true).to(false)
+  end
+end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -1,22 +1,30 @@
 # frozen_string_literal: true
 
 RSpec.describe CollectionPolicy, type: :policy do
-  let!(:user) { FactoryBot.create :user }
+  let_it_be(:user, refind: true) { FactoryBot.create :user }
 
-  let!(:collection) { FactoryBot.create :collection }
+  let_it_be(:community) { FactoryBot.create :community }
 
-  let!(:subcollection) { FactoryBot.create :collection, parent: collection }
+  let_it_be(:collection, refind: true) { FactoryBot.create :collection, community:, title: "Collection" }
 
-  let!(:other_collection) { FactoryBot.create :collection }
+  let_it_be(:subcollection, refind: true) { FactoryBot.create :collection, parent: collection, title: "Subcollection" }
 
-  let!(:contextual_role) { FactoryBot.create :role, :all_contextual }
+  let_it_be(:other_community, refind: true) { FactoryBot.create :community }
 
-  let!(:scope) { described_class::Scope.new(user, Collection.all) }
+  let_it_be(:other_collection, refind: true) { FactoryBot.create :collection, community: other_community, title: "Other Collection" }
+
+  let_it_be(:manager_role) { FactoryBot.create :role, :manager }
+
+  let_it_be(:editor_role) { FactoryBot.create :role, :editor }
+
+  let_it_be(:contextual_role) { FactoryBot.create :role, :all_contextual }
+
+  let(:scope) { described_class::Scope.new(user, Collection.all) }
 
   subject { described_class }
 
   context "as an admin" do
-    let!(:user) { FactoryBot.create :user, :admin }
+    let_it_be(:user) { FactoryBot.create :user, :admin }
 
     permissions ".scope" do
       subject { scope.resolve }
@@ -47,21 +55,139 @@ RSpec.describe CollectionPolicy, type: :policy do
     end
   end
 
+  context "as a user with manager access on the parent community" do
+    before do
+      grant_access! manager_role, on: community, to: user
+    end
+
+    permissions :read?, :show? do
+      it "is allowed on a collection" do
+        is_expected.to permit(user, collection)
+      end
+
+      it "is allowed on a subcollection" do
+        is_expected.to permit(user, subcollection)
+      end
+    end
+
+    permissions :create?, :update?, :destroy? do
+      it "is allowed on a collection" do
+        is_expected.to permit(user, collection)
+      end
+
+      it "is allowed on a subcollection" do
+        is_expected.to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+
+    permissions :manage_access? do
+      it "is allowed on the collection" do
+        is_expected.to permit(user, collection)
+      end
+
+      it "is allowed on a subcollection" do
+        is_expected.to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+
+    permissions :create_collections?, :create_items? do
+      it "is allowed on a collection" do
+        is_expected.to permit(user, collection)
+      end
+
+      it "is allowed on a subcollection" do
+        is_expected.to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+  end
+
+  context "as a user with editor access on the parent community" do
+    before do
+      grant_access! editor_role, on: community, to: user
+    end
+
+    permissions :read?, :show? do
+      it "is allowed on a collection" do
+        is_expected.to permit(user, collection)
+      end
+
+      it "is allowed on a subcollection" do
+        is_expected.to permit(user, subcollection)
+      end
+    end
+
+    permissions :create?, :destroy? do
+      it "is not allowed on a collection" do
+        is_expected.not_to permit(user, collection)
+      end
+
+      it "is not allowed on a subcollection" do
+        is_expected.not_to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+
+    permissions :update? do
+      it "is allowed on a collection" do
+        is_expected.to permit(user, collection)
+      end
+
+      it "is allowed on a subcollection" do
+        is_expected.to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+
+    permissions :manage_access? do
+      it "is not allowed on the collection" do
+        is_expected.not_to permit(user, collection)
+      end
+
+      it "is not allowed on a subcollection" do
+        is_expected.not_to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+
+    permissions :create_collections?, :create_items? do
+      it "is not allowed on a collection" do
+        is_expected.not_to permit(user, collection)
+      end
+
+      it "is not allowed on a subcollection" do
+        is_expected.not_to permit(user, subcollection)
+      end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
+    end
+  end
+
   context "as a user with all contextual permissions" do
     before do
       grant_access! contextual_role, on: collection, to: user
-    end
-
-    permissions ".scope" do
-      subject { scope.resolve }
-
-      it "includes what the user has read access to" do
-        is_expected.to include collection, subcollection
-      end
-
-      it "excludes what a user can't see" do
-        is_expected.not_to include other_collection
-      end
     end
 
     permissions :read?, :show?, :create?, :update?, :destroy? do
@@ -88,15 +214,23 @@ RSpec.describe CollectionPolicy, type: :policy do
       it "is allowed on a subcollection" do
         is_expected.to permit(user, subcollection)
       end
+
+      it "is not allowed on an unrelated collection" do
+        is_expected.not_to permit(user, other_collection)
+      end
     end
   end
 
   context "as a random user with no permissions" do
     permissions ".scope" do
+      before do
+        other_collection.update!(visibility: :hidden)
+      end
+
       subject { scope.resolve }
 
-      it "is empty" do
-        is_expected.to be_blank
+      it "excludes hidden records" do
+        is_expected.to exclude(other_collection).and include(collection, subcollection)
       end
     end
 
@@ -113,7 +247,9 @@ RSpec.describe CollectionPolicy, type: :policy do
     end
 
     context "when the collection is hidden" do
-      let(:collection) { FactoryBot.create :collection, :hidden }
+      before do
+        collection.update!(visibility: :hidden)
+      end
 
       permissions :show? do
         it "is disallowed" do
@@ -124,13 +260,17 @@ RSpec.describe CollectionPolicy, type: :policy do
   end
 
   context "as an anonymous user" do
-    let(:user) { AnonymousUser.new }
+    let_it_be(:user) { AnonymousUser.new }
 
     permissions ".scope" do
+      before do
+        other_collection.update!(visibility: :hidden)
+      end
+
       subject { scope.resolve }
 
-      it "is empty" do
-        is_expected.to be_blank
+      it "excludes hidden records" do
+        is_expected.to exclude(other_collection).and include(collection, subcollection)
       end
     end
 
@@ -147,7 +287,9 @@ RSpec.describe CollectionPolicy, type: :policy do
     end
 
     context "when the collection is hidden" do
-      let(:collection) { FactoryBot.create :collection, :hidden }
+      before do
+        collection.update!(visibility: :hidden)
+      end
 
       permissions :show? do
         it "is disallowed" do

--- a/spec/policies/community_policy_spec.rb
+++ b/spec/policies/community_policy_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe CommunityPolicy, type: :policy do
-  let!(:user) { FactoryBot.create :user }
+  let_it_be(:user, refind: true) { FactoryBot.create :user }
 
-  let!(:community) { FactoryBot.create :community }
+  let_it_be(:community, refind: true) { FactoryBot.create :community, title: "Community" }
 
-  let!(:other_community) { FactoryBot.create :community }
+  let_it_be(:other_community, refind: true) { FactoryBot.create :community, title: "Other Community" }
 
-  let!(:manager_role) { Role.fetch :manager }
+  let_it_be(:manager_role, refind: true) { Role.fetch :manager }
 
   let!(:scope) { described_class::Scope.new(user, Community.all) }
 
   subject { described_class }
 
   context "as a user with admin access" do
-    let!(:user) { FactoryBot.create :user, :admin }
+    let_it_be(:user) { FactoryBot.create :user, :admin }
 
     permissions ".scope" do
       subject { scope.resolve }
@@ -43,12 +43,8 @@ RSpec.describe CommunityPolicy, type: :policy do
     permissions ".scope" do
       subject { scope.resolve }
 
-      it "include what a user has access to" do
-        is_expected.to include community
-      end
-
-      it "excludes what a user can't see" do
-        is_expected.not_to include other_community
+      it "includes everything" do
+        is_expected.to include community, other_community
       end
     end
 
@@ -86,13 +82,13 @@ RSpec.describe CommunityPolicy, type: :policy do
   end
 
   context "as a user with no special access" do
-    let!(:user) { FactoryBot.create :user }
+    let_it_be(:user) { FactoryBot.create :user }
 
     permissions ".scope" do
       subject { scope.resolve }
 
-      it "includes nothing" do
-        is_expected.to be_blank
+      it "includes all communities" do
+        is_expected.to include(community, other_community)
       end
     end
 
@@ -110,13 +106,13 @@ RSpec.describe CommunityPolicy, type: :policy do
   end
 
   context "as an anonymous user" do
-    let!(:user) { AnonymousUser.new }
+    let_it_be(:user) { AnonymousUser.new }
 
     permissions ".scope" do
       subject { scope.resolve }
 
-      it "includes nothing" do
-        is_expected.to be_blank
+      it "includes all communities" do
+        is_expected.to include(community, other_community)
       end
     end
 

--- a/spec/requests/graphql/mutations/grant_access_spec.rb
+++ b/spec/requests/graphql/mutations/grant_access_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Mutations::GrantAccess, type: :request, graphql: :mutation do
+RSpec.describe Mutations::GrantAccess, type: :request, graphql: :mutation, grants_access: true do
   let!(:current_user) { FactoryBot.create :user }
 
   let!(:token) { token_helper.build_token(from_user: current_user) }
@@ -15,14 +15,14 @@ RSpec.describe Mutations::GrantAccess, type: :request, graphql: :mutation do
   }
   GRAPHQL
 
-  let(:admin) { Role.fetch(:admin) }
-  let(:manager) { Role.fetch(:manager) }
-  let(:editor) { Role.fetch(:editor) }
-  let(:reader) { Role.fetch(:reader) }
+  let_it_be(:admin) { Role.fetch(:admin) }
+  let_it_be(:manager) { Role.fetch(:manager) }
+  let_it_be(:editor) { Role.fetch(:editor) }
+  let_it_be(:reader) { Role.fetch(:reader) }
 
-  let!(:community) { FactoryBot.create :community }
+  let_it_be(:community, refind: true) { FactoryBot.create :community }
 
-  let!(:entity) { FactoryBot.create :collection, community: }
+  let_it_be(:entity, refind: true) { FactoryBot.create :collection, community: }
   let!(:role) { reader }
   let!(:user) { FactoryBot.create :user }
 
@@ -126,7 +126,7 @@ RSpec.describe Mutations::GrantAccess, type: :request, graphql: :mutation do
 
   context "as a community manager" do
     before do
-      MeruAPI::Container["access.grant"].call(manager, on: community, to: current_user)
+      grant_access! manager, on: community, to: current_user
     end
 
     context "when granting reader access on an entity" do

--- a/spec/requests/graphql/query/harvest_attempt_spec.rb
+++ b/spec/requests/graphql/query/harvest_attempt_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Query.harvestAttempt", type: :request do
 
   as_a_regular_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do
@@ -65,7 +65,7 @@ RSpec.describe "Query.harvestAttempt", type: :request do
 
   as_an_anonymous_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do

--- a/spec/requests/graphql/query/harvest_mapping_spec.rb
+++ b/spec/requests/graphql/query/harvest_mapping_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Query.harvestMapping", type: :request do
 
   as_a_regular_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do
@@ -76,7 +76,7 @@ RSpec.describe "Query.harvestMapping", type: :request do
 
   as_an_anonymous_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do

--- a/spec/requests/graphql/query/harvest_set_spec.rb
+++ b/spec/requests/graphql/query/harvest_set_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Query.harvestSet", type: :request do
 
   as_a_regular_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do
@@ -73,7 +73,7 @@ RSpec.describe "Query.harvestSet", type: :request do
 
   as_an_anonymous_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do

--- a/spec/requests/graphql/query/harvest_source_spec.rb
+++ b/spec/requests/graphql/query/harvest_source_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Query.harvestSource", type: :request do
 
   as_a_regular_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do
@@ -65,7 +65,7 @@ RSpec.describe "Query.harvestSource", type: :request do
 
   as_an_anonymous_user do
     context "when looking for an existing model" do
-      include_examples "a found record"
+      include_examples "a not found record"
     end
 
     context "when looking for an unknown model" do


### PR DESCRIPTION
* Correct issue where reparented entities didn't clean up their old access permissions, causing users to have access to child entities they shouldn't have anymore.
* Ensure objects are being authorized in GQL on each fetch
* Revise how policy scopes are evaluated for entities (assume most things are readable unless explicitly hidden and non-admin user)
* Add `access` filters to all entity resolvers (including search)
* Change EntityPermissionFilter enum `CRUD` to `UPDATE` and add `SKIP`
* Add many missing policy classes; revise readability concerns
* Ensure template entity lists only show visible entities, regardless of user access.
* Don't use asset permission grids for assets—defer to entity instead.
* Better integrate entity visibility checks so that communities can be always visible, as well as connecting visibility with ordering entry candidates, etc