### PR TITLE
[E] Add OAIDC harvesting templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=secret,id=maxmind_account_id \
   GEOIPUPDATE_LICENSE_KEY_FILE=/run/secrets/maxmind_license_key \
   /usr/bin/geoipupdate
 
-FROM ruby:3.2.3-bullseye
+FROM ruby:3.2.3-bookworm
 
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     build-essential \

--- a/app/operations/harvesting/mappings/upsert.rb
+++ b/app/operations/harvesting/mappings/upsert.rb
@@ -10,12 +10,14 @@ module Harvesting
       # @param [HarvestSet, nil] set
       # @param [Hash] options
       # @return [Dry::Monads::Success(HarvestMapping)]
-      def call(harvest_source, target_entity, set: nil, **options)
+      def call(harvest_source, target_entity, extraction_mapping_template: nil, set: nil, **options)
         mapping = harvest_source.harvest_mappings.by_target(target_entity).by_set(set).first_or_initialize do |to_create|
           to_create.inherit_harvesting_options_from! harvest_source
         end
 
         mapping.merge_harvesting_options!(**options)
+
+        mapping.extraction_mapping_template = extraction_mapping_template if extraction_mapping_template.present?
 
         monadic_save mapping
       end

--- a/app/operations/harvesting/sources/upsert.rb
+++ b/app/operations/harvesting/sources/upsert.rb
@@ -6,13 +6,14 @@ module Harvesting
       include MonadicPersistence
 
       # @return [Dry::Monads::Success(HarvestSource)]
-      def call(identifier, name, base_url, protocol:, metadata_format:, **options)
+      def call(identifier, name, base_url, protocol:, metadata_format:, extraction_mapping_template: nil, **options)
         source = HarvestSource.to_upsert_by_identifier(identifier)
 
         source.name = name
         source.base_url = base_url
         source.protocol = protocol
         source.metadata_format = metadata_format
+        source.extraction_mapping_template = extraction_mapping_template if extraction_mapping_template.present?
 
         source.merge_harvesting_options!(**options)
 

--- a/app/operations/protocols/oai/build_client_from_source.rb
+++ b/app/operations/protocols/oai/build_client_from_source.rb
@@ -12,7 +12,7 @@ module Protocols
       # @param [HarvestSource] harvest_source
       # @return [Dry::Monads::Success(::OAI::Client)]
       def call(harvest_source)
-        build_client.(harvest_source.base_url)
+        build_client.(harvest_source.base_url, allow_insecure: harvest_source.allow_insecure)
       end
     end
   end

--- a/app/services/harvesting/metadata/oaidc/context.rb
+++ b/app/services/harvesting/metadata/oaidc/context.rb
@@ -16,6 +16,11 @@ module Harvesting
         # @return [void]
         def build_root_drop!
           @assigns[:oaidc] = @root.to_liquid
+          @assigns[:journal] = Harvesting::Metadata::OAIDC::JournalDrop.new(@root.find_journal_source)
+          @assigns[:doi] = @root.find_doi
+          @assigns[:pdf] = Harvesting::Metadata::OAIDC::PDFDrop.new(@root.find_pdf_url)
+          @assigns[:creators] = @root.valid_creator_names.map(&:to_liquid)
+          @assigns[:contributors] = @root.valid_contributor_names.map(&:to_liquid)
         end
 
         # @return [void]

--- a/app/services/harvesting/metadata/oaidc/journal_drop.rb
+++ b/app/services/harvesting/metadata/oaidc/journal_drop.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Harvesting
+  module Metadata
+    module OAIDC
+      class JournalDrop < ::Liquid::Drop
+        # @param [Harvesting::Utility::ParsedJournalSource] journal_source
+        def initialize(journal_source = nil)
+          @journal_source = journal_source
+
+          @volume = @journal_source&.volume
+          @issue = @journal_source&.issue
+          @exists = @journal_source&.valid?
+        end
+
+        # @return [Boolean]
+        attr_reader :exists
+
+        # @return [String, nil]
+        attr_reader :issue
+
+        # @return [String, nil]
+        attr_reader :volume
+      end
+    end
+  end
+end

--- a/app/services/harvesting/metadata/oaidc/name_drop.rb
+++ b/app/services/harvesting/metadata/oaidc/name_drop.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Harvesting
+  module Metadata
+    module OAIDC
+      class NameDrop < ::Liquid::Drop
+        # @param [Metadata::OAIDC::Naming::Name] name
+        def initialize(name)
+          @name = name
+          @given = name.given
+          @family = name.family
+
+          @display_name = name.display_name
+
+          @exists = @name.valid?
+        end
+
+        # @return [String]
+        attr_reader :display_name
+
+        alias to_s display_name
+
+        # @return [Boolean]
+        attr_reader :exists
+
+        # @return [String]
+        attr_reader :family
+
+        # @return [String]
+        attr_reader :given
+      end
+    end
+  end
+end

--- a/app/services/harvesting/metadata/oaidc/pdf_drop.rb
+++ b/app/services/harvesting/metadata/oaidc/pdf_drop.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Harvesting
+  module Metadata
+    module OAIDC
+      class PDFDrop < ::Liquid::Drop
+        # @param [String, nil] url
+        def initialize(url = nil)
+          @url = url
+
+          @exists = @url.present?
+        end
+
+        # @return [Boolean]
+        attr_reader :exists
+
+        # @return [String, nil]
+        attr_reader :url
+      end
+    end
+  end
+end

--- a/app/services/harvesting/utility/parsed_journal_source.rb
+++ b/app/services/harvesting/utility/parsed_journal_source.rb
@@ -16,6 +16,8 @@ module Harvesting
         !unknown?
       end
 
+      alias valid? known?
+
       def unknown?
         volume == "UNKNOWN" && issue == "UNKNOWN"
       end

--- a/app/services/metadata/oaidc/elements/contributor.rb
+++ b/app/services/metadata/oaidc/elements/contributor.rb
@@ -4,6 +4,8 @@ module Metadata
   module OAIDC
     module Elements
       class Contributor < Metadata::OAIDC::AbstractElement
+        include ::Metadata::OAIDC::Naming::HasName
+
         xml do
           root "contributor"
         end

--- a/app/services/metadata/oaidc/elements/creator.rb
+++ b/app/services/metadata/oaidc/elements/creator.rb
@@ -4,6 +4,8 @@ module Metadata
   module OAIDC
     module Elements
       class Creator < Metadata::OAIDC::AbstractElement
+        include ::Metadata::OAIDC::Naming::HasName
+
         xml do
           root "creator"
         end

--- a/app/services/metadata/oaidc/elements/format.rb
+++ b/app/services/metadata/oaidc/elements/format.rb
@@ -7,6 +7,10 @@ module Metadata
         xml do
           root "format"
         end
+
+        def pdf?
+          content == "application/pdf"
+        end
       end
     end
   end

--- a/app/services/metadata/oaidc/elements/identifier.rb
+++ b/app/services/metadata/oaidc/elements/identifier.rb
@@ -7,6 +7,10 @@ module Metadata
         xml do
           root "identifier"
         end
+
+        def doi?
+          ::Entities::Types::DOI_PATTERN.match?(content)
+        end
       end
     end
   end

--- a/app/services/metadata/oaidc/elements/source.rb
+++ b/app/services/metadata/oaidc/elements/source.rb
@@ -7,6 +7,14 @@ module Metadata
         xml do
           root "source"
         end
+
+        def has_journal_source?
+          journal_source.known?
+        end
+
+        def journal_source
+          @journal_source ||= MeruAPI::Container["harvesting.utility.parse_journal_source"].(content)
+        end
       end
     end
   end

--- a/app/services/metadata/oaidc/naming/has_name.rb
+++ b/app/services/metadata/oaidc/naming/has_name.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Metadata
+  module OAIDC
+    module Naming
+      module HasName
+        extend ActiveSupport::Concern
+
+        def has_name
+          name.valid?
+        end
+
+        alias has_name? has_name
+
+        def name
+          @name ||= Metadata::OAIDC::Naming::Name.parse(content)
+        end
+      end
+    end
+  end
+end

--- a/app/services/metadata/oaidc/naming/name.rb
+++ b/app/services/metadata/oaidc/naming/name.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Metadata
+  module OAIDC
+    module Naming
+      class Name
+        include ActiveModel::Validations
+        include Dry::Core::Constants
+        include Dry::Initializer[undefined: false].define -> do
+          option :input, Metadata::Types::String.optional, optional: true
+          option :parsed, Metadata::Types::NamaeValues, default: proc { EMPTY_ARRAY }
+          option :matched, Metadata::Types::NamaeValue.optional, default: proc { parsed.first }
+          option :given, Metadata::Types::String.optional, default: proc { matched&.given&.to_s&.strip }
+          option :family, Metadata::Types::String.optional, default: proc { matched&.family&.to_s&.strip }
+        end
+
+        validates :given, :family, presence: true
+
+        def display_name
+          input.presence || "#{family}, #{given}"
+        end
+
+        # @return [Harvesting::Metadata::OAIDC::NameDrop]
+        def to_liquid
+          ::Harvesting::Metadata::OAIDC::NameDrop.new(self)
+        end
+
+        class << self
+          def parse(input)
+            parsed = Namae.parse(input)
+
+            new(input:, parsed:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/metadata/oaidc/root.rb
+++ b/app/services/metadata/oaidc/root.rb
@@ -41,6 +41,36 @@ module Metadata
         map_element "coverage", to: :coverage, namespace: DC_NS, prefix: "dc"
         map_element "rights", to: :rights, namespace: DC_NS, prefix: "dc"
       end
+
+      def find_doi
+        identifier.detect(&:doi?)&.content
+      end
+
+      def find_journal_source
+        source.detect(&:has_journal_source?)&.journal_source
+      end
+
+      def find_pdf_url
+        idx = format.index(&:pdf?)
+
+        return if idx.blank?
+
+        relation[idx]&.content
+      end
+
+      def valid_contributor_names
+        valid_names_from contributor
+      end
+
+      def valid_creator_names
+        valid_names_from creator
+      end
+
+      private
+
+      def valid_names_from(elements)
+        elements.map(&:name).select(&:valid?)
+      end
     end
   end
 end

--- a/app/services/metadata/shared/abstract_drop.rb
+++ b/app/services/metadata/shared/abstract_drop.rb
@@ -23,10 +23,26 @@ module Metadata
       def initialize(data, metadata_context: nil)
         super()
 
-        @data = data
+        @data = @object = data
 
         run_callbacks :initialize do
           @metadata_context = metadata_context || parent_metadata_context
+        end
+      end
+
+      def to_liquid
+        if has_string_content?
+          content
+        else
+          super
+        end
+      end
+
+      def to_s
+        if has_string_content?
+          content
+        else
+          super
         end
       end
 
@@ -44,6 +60,10 @@ module Metadata
             value.to_liquid
           end
         end
+      end
+
+      def has_string_content?
+        respond_to?(:content) && content.kind_of?(String) && content.present?
       end
 
       # @return [::Harvesting::Metadata::Context, nil]

--- a/app/services/metadata/types.rb
+++ b/app/services/metadata/types.rb
@@ -8,6 +8,10 @@ module Metadata
 
     EnumeratedStringList = Coercible::Array.of(Coercible::String.constrained(filled: true))
 
+    NamaeValue = Instance(::Namae::Name)
+
+    NamaeValues = Array.of(NamaeValue)
+
     NamespacePrefix = String.constrained(filled: true) | Nil
 
     NamespaceValue = String.constrained(filled: true)

--- a/app/services/pilot_harvesting/source_upserter.rb
+++ b/app/services/pilot_harvesting/source_upserter.rb
@@ -7,6 +7,8 @@ module PilotHarvesting
       param :harvestable, PilotHarvesting::Types.Instance(::PilotHarvesting::Harvestable)
 
       param :target_entity, Harvesting::Types::Target
+
+      option :extraction_mapping_template, Harvesting::Types::String.optional, optional: true
     end
 
     standard_execution!
@@ -78,6 +80,7 @@ module PilotHarvesting
 
     wrapped_hook! def upsert_source
       options = {
+        extraction_mapping_template:,
         mapping_options:,
         read_options:,
         metadata_format:,
@@ -113,6 +116,7 @@ module PilotHarvesting
 
     wrapped_hook! def upsert_mapping
       options = {
+        extraction_mapping_template:,
         mapping_options:,
         read_options:,
         set: harvest_set,
@@ -130,6 +134,7 @@ module PilotHarvesting
 
     wrapped_hook! def create_attempt
       @harvest_attempt = harvest_mapping.create_attempt(
+        extraction_mapping_template:,
         harvest_set:,
         target_entity:,
       )

--- a/app/services/protocols/oai/client_builder.rb
+++ b/app/services/protocols/oai/client_builder.rb
@@ -9,6 +9,8 @@ module Protocols
     class ClientBuilder < Support::HookBased::Actor
       include Dry::Initializer[undefined: false].define -> do
         param :base_url, Protocols::Types::URL
+
+        option :allow_insecure, Protocols::Types::Bool, default: proc { false }
       end
 
       standard_execution!
@@ -59,6 +61,10 @@ module Protocols
           builder.request :retry, retry_options
           builder.response :follow_redirects, limit: 5
           builder.adapter :net_http
+
+          if allow_insecure
+            builder.ssl.verify = false
+          end
         end
       end
     end

--- a/db/migrate/20250429192158_add_allow_insecure_to_harvest_sources.rb
+++ b/db/migrate/20250429192158_add_allow_insecure_to_harvest_sources.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAllowInsecureToHarvestSources < ActiveRecord::Migration[7.0]
+  def change
+    change_table :harvest_sources do |t|
+      t.boolean :allow_insecure, null: false, default: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5180,7 +5180,8 @@ CREATE TABLE public.harvest_sources (
     identifier public.citext NOT NULL,
     extraction_mapping_template text DEFAULT ''::text NOT NULL,
     checked_at timestamp without time zone,
-    status public.harvest_source_status DEFAULT 'inactive'::public.harvest_source_status NOT NULL
+    status public.harvest_source_status DEFAULT 'inactive'::public.harvest_source_status NOT NULL,
+    allow_insecure boolean DEFAULT false NOT NULL
 );
 
 
@@ -13831,6 +13832,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250317193746'),
 ('20250317201446'),
 ('20250408162405'),
-('20250408163159');
+('20250408163159'),
+('20250429192158');
 
 

--- a/lib/frozen_record/harvesting/examples.yml
+++ b/lib/frozen_record/harvesting/examples.yml
@@ -9,11 +9,32 @@
   default: true
   protocol_name: "oai"
   metadata_format_name: "esploro"
+- id: default_oaidc
+  name: Default OAIDC Mapping
+  default: true
+  protocol_name: "oai"
+  metadata_format_name: "oaidc"
+  description: >
+    By default, we try to harvest OAIDC content into the paper schema.
+
+    Sometimes we harvest as journal content, though, so refer to the
+    "OAIDC Journal Article" example where necessary.
 - id: default_mets
   name: Default METS Mapping
   default: true
   protocol_name: "oai"
   metadata_format_name: "mets"
+- id: oaidc_journal_article
+  name: OAIDC Journal Article
+  default: false
+  protocol_name: "oai"
+  metadata_format_name: "oaidc"
+  description: >
+    When fetching an OAIDC source that represents a journal article,
+    the data needs to be parsed using special helpers we provide in
+    the liquid environment. These are available on the following
+    assigns in any OAIDC environment: `journal`, `creators`, `contributors`,
+    and `pdf`.
 - id: empty
   name: "Barebones Template"
   default: false

--- a/lib/frozen_record/static_cached_columns.yml
+++ b/lib/frozen_record/static_cached_columns.yml
@@ -8,7 +8,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -21,8 +21,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#accessible_id
@@ -34,8 +34,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#role_id
@@ -47,8 +47,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#user_id
@@ -60,8 +60,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#auth_path
@@ -73,8 +73,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#community_id
@@ -86,8 +86,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#collection_id
@@ -99,8 +99,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#item_id
@@ -112,8 +112,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#created_at
@@ -126,7 +126,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -140,7 +140,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -153,8 +153,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#subject_type
@@ -166,8 +166,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrant#subject_id
@@ -179,8 +179,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrantManagementLink#access_grant_id
@@ -192,8 +192,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AccessGrantManagementLink#user_id
@@ -205,8 +205,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#id
@@ -218,7 +218,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -231,8 +231,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#user_id
@@ -244,8 +244,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#entity_type
@@ -257,8 +257,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#entity_id
@@ -270,8 +270,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#subject_type
@@ -283,8 +283,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#subject_id
@@ -296,8 +296,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#context
@@ -310,7 +310,7 @@
     sql_type: analytics_context
     type: enum
   default: frontend
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Ahoy::Event#name
@@ -322,8 +322,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#properties
@@ -335,8 +335,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Event#time
@@ -348,8 +348,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#id
@@ -361,7 +361,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -374,8 +374,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#visitor_token
@@ -387,8 +387,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#user_id
@@ -400,8 +400,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#ip
@@ -413,8 +413,8 @@
   sql_type_metadata:
     sql_type: inet
     type: inet
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#user_agent
@@ -426,8 +426,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#referrer
@@ -439,8 +439,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#referring_domain
@@ -452,8 +452,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#landing_page
@@ -465,8 +465,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#browser
@@ -478,8 +478,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#os
@@ -491,8 +491,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#device_type
@@ -504,8 +504,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#country
@@ -517,8 +517,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#region
@@ -530,8 +530,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#city
@@ -543,8 +543,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#latitude
@@ -556,8 +556,8 @@
   sql_type_metadata:
     sql_type: double precision
     type: float
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#longitude
@@ -569,8 +569,8 @@
   sql_type_metadata:
     sql_type: double precision
     type: float
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#utm_source
@@ -582,8 +582,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#utm_medium
@@ -595,8 +595,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#utm_term
@@ -608,8 +608,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#utm_content
@@ -621,8 +621,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#utm_campaign
@@ -634,8 +634,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#app_version
@@ -647,8 +647,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#os_version
@@ -660,8 +660,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#platform
@@ -673,8 +673,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#started_at
@@ -686,8 +686,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#country_code
@@ -699,8 +699,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#region_code
@@ -712,8 +712,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#postal_code
@@ -725,8 +725,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ahoy::Visit#geocoded_at
@@ -738,8 +738,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#id
@@ -751,7 +751,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -764,8 +764,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#entity_id
@@ -777,8 +777,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#published_on
@@ -790,8 +790,8 @@
   sql_type_metadata:
     sql_type: date
     type: date
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#header
@@ -803,8 +803,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#teaser
@@ -816,8 +816,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#body
@@ -829,8 +829,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Announcement#created_at
@@ -843,7 +843,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -857,7 +857,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -870,7 +870,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -883,8 +883,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#attachable_id
@@ -896,8 +896,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#parent_id
@@ -909,8 +909,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#kind
@@ -923,7 +923,7 @@
     sql_type: asset_kind
     type: enum
   default: unknown
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Asset#position
@@ -936,8 +936,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#name
@@ -949,8 +949,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#content_type
@@ -962,8 +962,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#file_size
@@ -976,8 +976,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#alt_text
@@ -989,8 +989,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#caption
@@ -1002,8 +1002,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#attachment_data
@@ -1015,8 +1015,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#alternatives_data
@@ -1028,8 +1028,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#preview_data
@@ -1041,8 +1041,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#properties
@@ -1054,8 +1054,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#created_at
@@ -1068,7 +1068,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1082,7 +1082,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1095,8 +1095,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#collection_id
@@ -1108,8 +1108,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#item_id
@@ -1121,8 +1121,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Asset#identifier
@@ -1134,8 +1134,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AssignableRoleTarget#source_role_id
@@ -1147,8 +1147,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AssignableRoleTarget#priority
@@ -1161,8 +1161,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AssignableRoleTarget#target_role_id
@@ -1174,8 +1174,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AssignableRoleTarget#source_priority
@@ -1188,8 +1188,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AssignableRoleTarget#source_name
@@ -1201,8 +1201,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AssignableRoleTarget#target_name
@@ -1214,8 +1214,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedCollectionParent#collection_id
@@ -1227,8 +1227,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedCollectionParent#invalid_community_id
@@ -1240,8 +1240,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedCollectionParent#valid_community_id
@@ -1253,8 +1253,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#synced_entity_id
@@ -1266,8 +1266,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#real
@@ -1279,8 +1279,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#source_id
@@ -1292,8 +1292,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#source_type
@@ -1305,8 +1305,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#hierarchical_id
@@ -1318,8 +1318,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#hierarchical_type
@@ -1331,8 +1331,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#synced_schema_version_id
@@ -1344,8 +1344,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedEntitySchema#actual_schema_version_id
@@ -1357,8 +1357,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedItemParent#item_id
@@ -1370,8 +1370,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedItemParent#invalid_collection_id
@@ -1383,8 +1383,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Audits::MismatchedItemParent#valid_collection_id
@@ -1396,8 +1396,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AuthorizingEntity#auth_path
@@ -1409,8 +1409,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AuthorizingEntity#entity_id
@@ -1422,8 +1422,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AuthorizingEntity#scope
@@ -1435,8 +1435,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AuthorizingEntity#hierarchical_type
@@ -1448,8 +1448,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AuthorizingEntity#hierarchical_id
@@ -1461,8 +1461,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: AuthorizingEntity#created_at
@@ -1475,7 +1475,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1489,7 +1489,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1502,7 +1502,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -1515,8 +1515,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#schema_definition_id
@@ -1528,8 +1528,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#parent_id
@@ -1541,8 +1541,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#identifier
@@ -1554,8 +1554,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#system_slug
@@ -1567,8 +1567,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#title
@@ -1580,8 +1580,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#raw_doi
@@ -1593,8 +1593,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#summary
@@ -1607,7 +1607,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Collection#thumbnail_data
@@ -1619,8 +1619,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#properties
@@ -1632,8 +1632,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#created_at
@@ -1646,7 +1646,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1660,7 +1660,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1673,8 +1673,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#hierarchical_depth
@@ -1687,7 +1687,7 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
+  default:
   default_function: nlevel(auth_path)
   has_default: false
   virtual: true
@@ -1700,8 +1700,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#hero_image_data
@@ -1713,8 +1713,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#subtitle
@@ -1726,8 +1726,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#issn
@@ -1739,8 +1739,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Collection#has_doi
@@ -1753,7 +1753,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Collection#doi_data
@@ -1766,7 +1766,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Collection#doi
@@ -1778,7 +1778,7 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
+  default:
   default_function: extract_doi_from_data(doi_data)
   has_default: false
   virtual: true
@@ -1792,7 +1792,7 @@
     sql_type: harvest_modification_status
     type: enum
   default: unharvested
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: CollectionAttribution#id
@@ -1804,7 +1804,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -1817,8 +1817,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionAttribution#contributor_id
@@ -1830,8 +1830,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionAttribution#position
@@ -1844,8 +1844,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionAttribution#created_at
@@ -1858,7 +1858,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1872,7 +1872,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -1885,8 +1885,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionAuthorization#collection_id
@@ -1898,8 +1898,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionAuthorization#auth_path
@@ -1911,8 +1911,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#id
@@ -1924,7 +1924,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -1937,8 +1937,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#collection_id
@@ -1950,8 +1950,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#kind
@@ -1963,8 +1963,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#metadata
@@ -1976,8 +1976,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#created_at
@@ -1990,7 +1990,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2004,7 +2004,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2017,8 +2017,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#inner_position
@@ -2031,8 +2031,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionContribution#outer_position
@@ -2045,8 +2045,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionHierarchy#ancestor_id
@@ -2058,8 +2058,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionHierarchy#descendant_id
@@ -2071,8 +2071,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CollectionHierarchy#generations
@@ -2085,8 +2085,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#id
@@ -2098,7 +2098,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -2111,8 +2111,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#position
@@ -2125,8 +2125,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#title
@@ -2138,8 +2138,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#thumbnail_data
@@ -2151,8 +2151,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#metadata
@@ -2164,8 +2164,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#created_at
@@ -2178,7 +2178,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2192,7 +2192,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2205,8 +2205,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#hierarchical_depth
@@ -2219,7 +2219,7 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
+  default:
   default_function: nlevel(auth_path)
   has_default: false
   virtual: true
@@ -2232,8 +2232,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#schema_version_id
@@ -2245,8 +2245,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#properties
@@ -2258,8 +2258,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#hero_image_data
@@ -2271,8 +2271,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#subtitle
@@ -2284,8 +2284,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#hero_image_layout
@@ -2298,7 +2298,7 @@
     sql_type: text
     type: text
   default: one_column
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Community#logo_data
@@ -2310,8 +2310,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#summary
@@ -2323,8 +2323,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#tagline
@@ -2336,8 +2336,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Community#identifier
@@ -2349,8 +2349,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CommunityMembership#id
@@ -2362,7 +2362,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -2375,8 +2375,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CommunityMembership#role_id
@@ -2388,8 +2388,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CommunityMembership#user_id
@@ -2401,8 +2401,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: CommunityMembership#created_at
@@ -2415,7 +2415,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2429,7 +2429,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2442,8 +2442,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#hierarchical_type
@@ -2455,8 +2455,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#user_id
@@ -2468,8 +2468,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#has_any_role
@@ -2481,8 +2481,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#has_direct_role
@@ -2494,8 +2494,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#access_grant_ids
@@ -2507,8 +2507,8 @@
   sql_type_metadata:
     sql_type: uuid[]
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#role_ids
@@ -2520,8 +2520,8 @@
   sql_type_metadata:
     sql_type: uuid[]
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#allowed_actions
@@ -2533,8 +2533,8 @@
   sql_type_metadata:
     sql_type: ltree[]
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#access_control_list
@@ -2546,8 +2546,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#grid
@@ -2559,8 +2559,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#created_at
@@ -2572,8 +2572,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualPermission#updated_at
@@ -2585,8 +2585,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#hierarchical_id
@@ -2598,8 +2598,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#hierarchical_type
@@ -2611,8 +2611,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#user_id
@@ -2624,8 +2624,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#permission_id
@@ -2637,8 +2637,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#action
@@ -2650,8 +2650,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#access_grant_id
@@ -2663,8 +2663,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#role_id
@@ -2676,8 +2676,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextualSinglePermission#directly_assigned
@@ -2689,8 +2689,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignableRole#hierarchical_id
@@ -2702,8 +2702,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignableRole#hierarchical_type
@@ -2715,8 +2715,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignableRole#user_id
@@ -2728,8 +2728,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignableRole#role_id
@@ -2741,8 +2741,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignableRole#priority
@@ -2755,8 +2755,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedAccessGrant#hierarchical_id
@@ -2768,8 +2768,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedAccessGrant#hierarchical_type
@@ -2781,8 +2781,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedAccessGrant#user_id
@@ -2794,8 +2794,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedAccessGrant#access_grant_id
@@ -2807,8 +2807,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedRole#hierarchical_id
@@ -2820,8 +2820,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedRole#hierarchical_type
@@ -2833,8 +2833,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedRole#user_id
@@ -2846,8 +2846,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContextuallyAssignedRole#role_id
@@ -2859,8 +2859,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributionRoleConfiguration#id
@@ -2872,7 +2872,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -2885,8 +2885,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributionRoleConfiguration#default_item_id
@@ -2898,8 +2898,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributionRoleConfiguration#other_item_id
@@ -2911,8 +2911,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributionRoleConfiguration#source_type
@@ -2924,8 +2924,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributionRoleConfiguration#source_id
@@ -2937,8 +2937,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributionRoleConfiguration#created_at
@@ -2951,7 +2951,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2965,7 +2965,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -2978,7 +2978,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -2991,8 +2991,8 @@
   sql_type_metadata:
     sql_type: contributor_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#identifier
@@ -3004,8 +3004,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#email
@@ -3017,8 +3017,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#prefix
@@ -3030,8 +3030,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#suffix
@@ -3043,8 +3043,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#bio
@@ -3056,8 +3056,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#url
@@ -3069,8 +3069,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#image_data
@@ -3082,8 +3082,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#properties
@@ -3095,8 +3095,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#links
@@ -3108,8 +3108,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#created_at
@@ -3122,7 +3122,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3136,7 +3136,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3151,7 +3151,7 @@
     type: integer
     limit: 8
   default: '0'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Contributor#item_contribution_count
@@ -3165,7 +3165,7 @@
     type: integer
     limit: 8
   default: '0'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Contributor#contribution_count
@@ -3178,7 +3178,7 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
+  default:
   default_function: "(GREATEST(collection_contribution_count, (0)::bigint) + GREATEST(item_contribution_count,
     (0)::bigint))"
   has_default: false
@@ -3192,7 +3192,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: derive_contributor_name(kind, properties)
   has_default: false
   virtual: true
@@ -3205,7 +3205,7 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
+  default:
   default_function: derive_contributor_sort_name(kind, properties)
   has_default: false
   virtual: true
@@ -3218,7 +3218,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: derive_contributor_affiliation(kind, properties)
   has_default: false
   virtual: true
@@ -3231,8 +3231,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Contributor#search_name
@@ -3244,7 +3244,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: to_prefix_search(derive_contributor_name(kind, properties))
   has_default: false
   virtual: true
@@ -3258,7 +3258,7 @@
     sql_type: harvest_modification_status
     type: enum
   default: unharvested
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ContributorAttribution#attribution_id
@@ -3270,8 +3270,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#attribution_type
@@ -3283,8 +3283,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#contributor_id
@@ -3296,8 +3296,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#collection_id
@@ -3309,8 +3309,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#item_id
@@ -3322,8 +3322,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#entity_id
@@ -3335,8 +3335,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#entity_type
@@ -3348,8 +3348,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#kind
@@ -3361,8 +3361,8 @@
   sql_type_metadata:
     sql_type: child_entity_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#title
@@ -3374,8 +3374,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#has_published
@@ -3387,8 +3387,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#published
@@ -3400,8 +3400,8 @@
   sql_type_metadata:
     sql_type: variable_precision_date
     type: variable_precision_date
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#published_on
@@ -3413,8 +3413,8 @@
   sql_type_metadata:
     sql_type: date
     type: date
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#published_rank
@@ -3427,8 +3427,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#title_rank
@@ -3441,8 +3441,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#created_at
@@ -3455,8 +3455,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ContributorAttribution#updated_at
@@ -3469,8 +3469,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#id
@@ -3482,7 +3482,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -3495,8 +3495,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#identifier
@@ -3508,8 +3508,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#version
@@ -3521,8 +3521,8 @@
   sql_type_metadata:
     sql_type: semantic_version
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#provides
@@ -3534,8 +3534,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#name
@@ -3547,8 +3547,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#description
@@ -3560,8 +3560,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#items_count
@@ -3575,7 +3575,7 @@
     type: integer
     limit: 8
   default: '0'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ControlledVocabulary#item_identifiers
@@ -3588,7 +3588,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ControlledVocabulary#item_set
@@ -3600,8 +3600,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabulary#created_at
@@ -3614,7 +3614,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3628,7 +3628,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3641,7 +3641,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -3654,8 +3654,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#parent_id
@@ -3667,8 +3667,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#position
@@ -3681,8 +3681,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#identifier
@@ -3694,8 +3694,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#label
@@ -3707,8 +3707,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#description
@@ -3720,8 +3720,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#url
@@ -3733,8 +3733,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#unselectable
@@ -3747,7 +3747,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ControlledVocabularyItem#created_at
@@ -3760,7 +3760,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3774,7 +3774,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3789,7 +3789,7 @@
     type: integer
     limit: 8
   default: '0'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ControlledVocabularyItem#ranking
@@ -3802,8 +3802,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItem#tags
@@ -3816,7 +3816,7 @@
     sql_type: citext[]
     type: citext
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ControlledVocabularyItemHierarchy#ancestor_id
@@ -3828,8 +3828,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItemHierarchy#descendant_id
@@ -3841,8 +3841,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularyItemHierarchy#generations
@@ -3855,8 +3855,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularySource#id
@@ -3868,7 +3868,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -3881,8 +3881,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularySource#provides
@@ -3894,8 +3894,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ControlledVocabularySource#created_at
@@ -3908,7 +3908,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3922,7 +3922,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -3935,7 +3935,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -3948,8 +3948,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#entity_id
@@ -3961,8 +3961,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#hierarchical_type
@@ -3974,8 +3974,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#hierarchical_id
@@ -3987,8 +3987,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#system_slug
@@ -4000,8 +4000,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#auth_path
@@ -4013,8 +4013,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#scope
@@ -4026,8 +4026,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#created_at
@@ -4040,7 +4040,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -4054,7 +4054,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -4068,7 +4068,7 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
+  default:
   default_function: nlevel(auth_path)
   has_default: false
   virtual: true
@@ -4081,8 +4081,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#link_operator
@@ -4094,8 +4094,8 @@
   sql_type_metadata:
     sql_type: link_operator
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#title
@@ -4108,7 +4108,7 @@
     sql_type: citext
     type: citext
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Entity#properties
@@ -4121,7 +4121,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Entity#stale_at
@@ -4133,8 +4133,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#refreshed_at
@@ -4146,8 +4146,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Entity#stale
@@ -4159,7 +4159,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((stale_at IS NOT NULL) AND ((refreshed_at IS NULL) OR (refreshed_at
     < stale_at)))"
   has_default: false
@@ -4173,8 +4173,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#entity_type
@@ -4186,8 +4186,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#entity_id
@@ -4199,8 +4199,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#name
@@ -4212,8 +4212,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#ancestor_type
@@ -4225,8 +4225,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#ancestor_id
@@ -4238,8 +4238,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#ancestor_schema_version_id
@@ -4251,8 +4251,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#origin_depth
@@ -4265,8 +4265,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#ancestor_depth
@@ -4279,8 +4279,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityAncestor#relative_depth
@@ -4293,8 +4293,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#entity_type
@@ -4306,8 +4306,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#entity_id
@@ -4319,8 +4319,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#entity_slug
@@ -4332,8 +4332,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#crumb_type
@@ -4345,8 +4345,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#crumb_id
@@ -4358,8 +4358,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#schema_version_id
@@ -4371,8 +4371,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#auth_path
@@ -4384,8 +4384,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#system_slug
@@ -4397,8 +4397,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityBreadcrumb#depth
@@ -4411,8 +4411,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityComposedText#id
@@ -4424,7 +4424,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -4437,8 +4437,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityComposedText#entity_id
@@ -4450,8 +4450,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityComposedText#document
@@ -4464,7 +4464,7 @@
     sql_type: tsvector
     type: tsvector
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: EntityComposedText#created_at
@@ -4477,7 +4477,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -4491,7 +4491,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -4504,8 +4504,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#parent_id
@@ -4517,8 +4517,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#descendant_type
@@ -4530,8 +4530,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#descendant_id
@@ -4543,8 +4543,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#schema_version_id
@@ -4556,8 +4556,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#link_operator
@@ -4569,8 +4569,8 @@
   sql_type_metadata:
     sql_type: link_operator
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#auth_path
@@ -4582,8 +4582,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#scope
@@ -4595,8 +4595,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#title
@@ -4608,8 +4608,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#actual_depth
@@ -4622,8 +4622,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#relative_depth
@@ -4636,8 +4636,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#created_at
@@ -4650,8 +4650,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityDescendant#updated_at
@@ -4664,8 +4664,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#id
@@ -4677,7 +4677,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -4690,8 +4690,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#ancestor_id
@@ -4703,8 +4703,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#descendant_type
@@ -4716,8 +4716,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#descendant_id
@@ -4729,8 +4729,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#hierarchical_type
@@ -4742,8 +4742,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#hierarchical_id
@@ -4755,8 +4755,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#schema_definition_id
@@ -4768,8 +4768,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#schema_version_id
@@ -4781,8 +4781,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#link_operator
@@ -4794,8 +4794,8 @@
   sql_type_metadata:
     sql_type: link_operator
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#ancestor_scope
@@ -4807,8 +4807,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#descendant_scope
@@ -4820,8 +4820,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#auth_path
@@ -4833,8 +4833,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#ancestor_slug
@@ -4846,8 +4846,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#descendant_slug
@@ -4859,8 +4859,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityHierarchy#created_at
@@ -4873,7 +4873,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -4887,7 +4887,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -4901,7 +4901,7 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
+  default:
   default_function: nlevel(auth_path)
   has_default: false
   virtual: true
@@ -4915,7 +4915,7 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
+  default:
   default_function: ltree_generations(auth_path, ancestor_slug, descendant_slug)
   has_default: false
   virtual: true
@@ -4928,8 +4928,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#schema_version_id
@@ -4941,8 +4941,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#entity_id
@@ -4954,8 +4954,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#entity_type
@@ -4967,8 +4967,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#ordering_id
@@ -4980,8 +4980,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#identifier
@@ -4993,8 +4993,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#missing
@@ -5006,8 +5006,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#modified
@@ -5019,8 +5019,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#mismatch
@@ -5032,8 +5032,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityInheritedOrdering#status
@@ -5045,8 +5045,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#id
@@ -5058,7 +5058,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -5071,8 +5071,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#source_id
@@ -5084,8 +5084,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#target_type
@@ -5097,8 +5097,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#target_id
@@ -5110,8 +5110,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#schema_version_id
@@ -5123,8 +5123,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#source_community_id
@@ -5136,8 +5136,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#source_collection_id
@@ -5149,8 +5149,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#source_item_id
@@ -5162,8 +5162,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#target_community_id
@@ -5175,8 +5175,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#target_collection_id
@@ -5188,8 +5188,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#target_item_id
@@ -5201,8 +5201,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#operator
@@ -5214,8 +5214,8 @@
   sql_type_metadata:
     sql_type: link_operator
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#auth_path
@@ -5227,8 +5227,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#scope
@@ -5240,8 +5240,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#system_slug
@@ -5253,8 +5253,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityLink#created_at
@@ -5267,7 +5267,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5281,7 +5281,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5294,7 +5294,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -5307,8 +5307,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#entity_id
@@ -5320,8 +5320,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#schema_version_property_id
@@ -5333,8 +5333,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#type
@@ -5346,8 +5346,8 @@
   sql_type_metadata:
     sql_type: schema_property_type
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#path
@@ -5359,8 +5359,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#fixed_position
@@ -5373,8 +5373,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#raw_value
@@ -5386,8 +5386,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityOrderableProperty#created_at
@@ -5400,7 +5400,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5414,7 +5414,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5427,7 +5427,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: generate_boolean_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5440,7 +5440,7 @@
   sql_type_metadata:
     sql_type: date
     type: date
-  default: 
+  default:
   default_function: generate_date_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5453,7 +5453,7 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
+  default:
   default_function: generate_email_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5466,7 +5466,7 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
+  default:
   default_function: generate_float_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5480,7 +5480,7 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
+  default:
   default_function: generate_integer_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5493,7 +5493,7 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
+  default:
   default_function: generate_string_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5506,7 +5506,7 @@
   sql_type_metadata:
     sql_type: timestamp with time zone
     type: timestamptz
-  default: 
+  default:
   default_function: generate_timestamp_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5519,7 +5519,7 @@
   sql_type_metadata:
     sql_type: variable_precision_date
     type: variable_precision_date
-  default: 
+  default:
   default_function: generate_variable_date_value(type, raw_value)
   has_default: false
   virtual: true
@@ -5532,7 +5532,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -5545,8 +5545,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#entity_id
@@ -5558,8 +5558,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#schema_version_property_id
@@ -5571,8 +5571,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#type
@@ -5584,8 +5584,8 @@
   sql_type_metadata:
     sql_type: schema_property_type
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#path
@@ -5597,8 +5597,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#raw_value
@@ -5610,8 +5610,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#boolean_value
@@ -5623,8 +5623,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#citext_value
@@ -5636,8 +5636,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#date_value
@@ -5649,8 +5649,8 @@
   sql_type_metadata:
     sql_type: date
     type: date
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#float_value
@@ -5662,8 +5662,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#integer_value
@@ -5676,8 +5676,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#text_value
@@ -5689,8 +5689,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#text_array_value
@@ -5703,7 +5703,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: EntitySearchableProperty#timestamp_value
@@ -5715,8 +5715,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntitySearchableProperty#variable_date_value
@@ -5729,7 +5729,7 @@
     sql_type: variable_precision_date
     type: variable_precision_date
   default: "(,none)"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: EntitySearchableProperty#created_at
@@ -5742,7 +5742,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5756,7 +5756,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5769,7 +5769,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -5782,8 +5782,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityVisibility#entity_id
@@ -5795,8 +5795,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityVisibility#visible_after_at
@@ -5808,8 +5808,8 @@
   sql_type_metadata:
     sql_type: timestamp with time zone
     type: timestamptz
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityVisibility#visible_until_at
@@ -5821,8 +5821,8 @@
   sql_type_metadata:
     sql_type: timestamp with time zone
     type: timestamptz
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityVisibility#hidden_at
@@ -5834,8 +5834,8 @@
   sql_type_metadata:
     sql_type: timestamp with time zone
     type: timestamptz
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: EntityVisibility#visibility
@@ -5848,7 +5848,7 @@
     sql_type: entity_visibility
     type: enum
   default: visible
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: EntityVisibility#created_at
@@ -5861,7 +5861,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5875,7 +5875,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5888,7 +5888,7 @@
   sql_type_metadata:
     sql_type: tstzrange
     type: tstzrange
-  default: 
+  default:
   default_function: calculate_visibility_range(visibility, visible_after_at, visible_until_at)
   has_default: false
   virtual: true
@@ -5901,7 +5901,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -5914,8 +5914,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: FakeVisitor#ip
@@ -5927,8 +5927,8 @@
   sql_type_metadata:
     sql_type: inet
     type: inet
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: FakeVisitor#user_agent
@@ -5940,8 +5940,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: FakeVisitor#sequence
@@ -5954,8 +5954,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: FakeVisitor#created_at
@@ -5968,7 +5968,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5982,7 +5982,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -5995,7 +5995,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6009,7 +6009,7 @@
     sql_type: boolean
     type: boolean
   default: 'true'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: GlobalConfiguration#created_at
@@ -6022,7 +6022,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6036,7 +6036,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6050,7 +6050,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: GlobalConfiguration#entities
@@ -6063,7 +6063,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: GlobalConfiguration#site
@@ -6076,7 +6076,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: GlobalConfiguration#theme
@@ -6089,7 +6089,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: GlobalConfiguration#logo_data
@@ -6101,8 +6101,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GlobalConfiguration#banner_data
@@ -6114,8 +6114,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#id
@@ -6127,7 +6127,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6140,8 +6140,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#permission_id
@@ -6153,8 +6153,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#user_id
@@ -6166,8 +6166,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#scope
@@ -6179,8 +6179,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#action
@@ -6192,8 +6192,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#role_id
@@ -6205,8 +6205,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#accessible_type
@@ -6218,8 +6218,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#accessible_id
@@ -6231,8 +6231,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#auth_path
@@ -6244,8 +6244,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: GrantedPermission#inferred
@@ -6258,7 +6258,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: GrantedPermission#created_at
@@ -6271,7 +6271,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6285,7 +6285,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6298,7 +6298,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6311,8 +6311,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#harvest_set_id
@@ -6324,8 +6324,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#harvest_mapping_id
@@ -6337,8 +6337,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#mode
@@ -6351,7 +6351,7 @@
     sql_type: text
     type: text
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestAttempt#description
@@ -6363,8 +6363,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#metadata
@@ -6377,7 +6377,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestAttempt#record_count
@@ -6390,8 +6390,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#began_at
@@ -6403,8 +6403,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#ended_at
@@ -6416,8 +6416,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#created_at
@@ -6430,7 +6430,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6444,7 +6444,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6457,8 +6457,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#target_entity_type
@@ -6470,8 +6470,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#target_entity_id
@@ -6483,8 +6483,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#extraction_mapping_template
@@ -6497,7 +6497,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestAttempt#scheduled_at
@@ -6509,8 +6509,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttempt#scheduling_key
@@ -6522,8 +6522,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptRecordLink#id
@@ -6535,7 +6535,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6548,8 +6548,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptRecordLink#harvest_record_id
@@ -6561,8 +6561,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptRecordLink#created_at
@@ -6575,7 +6575,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6589,7 +6589,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6602,7 +6602,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6615,8 +6615,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptTransition#most_recent
@@ -6628,8 +6628,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptTransition#sort_key
@@ -6642,8 +6642,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptTransition#to_state
@@ -6655,8 +6655,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptTransition#metadata
@@ -6668,8 +6668,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestAttemptTransition#created_at
@@ -6682,7 +6682,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6696,7 +6696,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6709,7 +6709,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6722,8 +6722,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#fetched_at
@@ -6735,8 +6735,8 @@
   sql_type_metadata:
     sql_type: timestamp with time zone
     type: timestamptz
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#touched_at
@@ -6748,8 +6748,8 @@
   sql_type_metadata:
     sql_type: timestamp with time zone
     type: timestamptz
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#file_size
@@ -6762,8 +6762,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#file_name
@@ -6775,8 +6775,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#content_type
@@ -6788,8 +6788,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#signature
@@ -6801,8 +6801,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#asset_data
@@ -6814,8 +6814,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAsset#metadata
@@ -6828,7 +6828,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestCachedAsset#created_at
@@ -6841,7 +6841,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6855,7 +6855,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6868,7 +6868,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6881,8 +6881,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAssetReference#cacheable_type
@@ -6894,8 +6894,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAssetReference#cacheable_id
@@ -6907,8 +6907,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestCachedAssetReference#created_at
@@ -6921,7 +6921,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6935,7 +6935,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -6948,7 +6948,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -6961,8 +6961,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#harvest_mapping_id
@@ -6974,8 +6974,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#harvest_set_id
@@ -6987,8 +6987,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#harvest_attempt_id
@@ -7000,8 +7000,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#target_entity_type
@@ -7013,8 +7013,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#target_entity_id
@@ -7026,8 +7026,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#metadata_format
@@ -7039,8 +7039,8 @@
   sql_type_metadata:
     sql_type: harvest_metadata_format
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestConfiguration#list_options
@@ -7053,7 +7053,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestConfiguration#read_options
@@ -7066,7 +7066,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestConfiguration#format_options
@@ -7079,7 +7079,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestConfiguration#mapping_options
@@ -7092,7 +7092,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestConfiguration#extraction_mapping_template
@@ -7105,7 +7105,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestConfiguration#created_at
@@ -7118,7 +7118,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7132,7 +7132,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7145,7 +7145,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -7158,8 +7158,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContribution#harvest_entity_id
@@ -7171,8 +7171,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContribution#legacy_kind
@@ -7184,8 +7184,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContribution#metadata
@@ -7197,8 +7197,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContribution#created_at
@@ -7211,7 +7211,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7225,7 +7225,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7238,8 +7238,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContribution#inner_position
@@ -7252,8 +7252,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContribution#outer_position
@@ -7266,8 +7266,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#id
@@ -7279,7 +7279,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -7292,8 +7292,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#contributor_id
@@ -7305,8 +7305,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#kind
@@ -7318,8 +7318,8 @@
   sql_type_metadata:
     sql_type: contributor_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#identifier
@@ -7331,8 +7331,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#email
@@ -7344,8 +7344,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#prefix
@@ -7357,8 +7357,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#suffix
@@ -7370,8 +7370,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#bio
@@ -7383,8 +7383,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#url
@@ -7396,8 +7396,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#properties
@@ -7409,8 +7409,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#links
@@ -7422,8 +7422,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestContributor#created_at
@@ -7436,7 +7436,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7450,7 +7450,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7464,7 +7464,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestContributor#tracked_properties
@@ -7477,7 +7477,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestContributor#orcid
@@ -7489,8 +7489,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#id
@@ -7502,7 +7502,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -7515,8 +7515,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#parent_id
@@ -7528,8 +7528,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#schema_version_id
@@ -7541,8 +7541,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#entity_type
@@ -7554,8 +7554,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#entity_id
@@ -7567,8 +7567,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#identifier
@@ -7580,8 +7580,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#metadata_kind
@@ -7593,8 +7593,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#extracted_attributes
@@ -7606,8 +7606,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#extracted_properties
@@ -7619,8 +7619,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#extracted_assets
@@ -7632,8 +7632,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#created_at
@@ -7646,7 +7646,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7660,7 +7660,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7673,8 +7673,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#existing_parent_id
@@ -7686,8 +7686,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#extracted_links
@@ -7699,8 +7699,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntity#entity_kind
@@ -7712,8 +7712,8 @@
   sql_type_metadata:
     sql_type: child_entity_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntityHierarchy#ancestor_id
@@ -7725,8 +7725,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntityHierarchy#descendant_id
@@ -7738,8 +7738,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestEntityHierarchy#generations
@@ -7752,8 +7752,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestError#id
@@ -7765,7 +7765,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -7778,8 +7778,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestError#source_id
@@ -7791,8 +7791,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestError#code
@@ -7804,8 +7804,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestError#message
@@ -7817,8 +7817,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestError#metadata
@@ -7831,7 +7831,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestError#created_at
@@ -7844,7 +7844,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7858,7 +7858,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -7871,7 +7871,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -7884,8 +7884,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#harvest_set_id
@@ -7897,8 +7897,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#mode
@@ -7911,7 +7911,7 @@
     sql_type: text
     type: text
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMapping#frequency
@@ -7923,8 +7923,8 @@
   sql_type_metadata:
     sql_type: interval
     type: interval
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#frequency_expression
@@ -7936,8 +7936,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#list_options
@@ -7950,7 +7950,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMapping#read_options
@@ -7963,7 +7963,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMapping#format_options
@@ -7976,7 +7976,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMapping#mapping_options
@@ -7989,7 +7989,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMapping#created_at
@@ -8002,7 +8002,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8016,7 +8016,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8029,8 +8029,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#target_entity_type
@@ -8042,8 +8042,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#target_entity_id
@@ -8055,8 +8055,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#extraction_mapping_template
@@ -8069,7 +8069,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMapping#schedule_changed_at
@@ -8081,8 +8081,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#last_scheduled_at
@@ -8094,8 +8094,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMapping#schedule_data
@@ -8108,7 +8108,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMappingRecordLink#id
@@ -8120,7 +8120,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8133,8 +8133,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMappingRecordLink#harvest_record_id
@@ -8146,8 +8146,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMappingRecordLink#created_at
@@ -8160,7 +8160,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8174,7 +8174,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8187,7 +8187,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8200,8 +8200,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMessage#harvest_attempt_id
@@ -8213,8 +8213,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMessage#harvest_mapping_id
@@ -8226,8 +8226,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMessage#harvest_record_id
@@ -8239,8 +8239,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMessage#harvest_entity_id
@@ -8252,8 +8252,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMessage#at
@@ -8265,7 +8265,7 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8279,7 +8279,7 @@
     sql_type: harvest_message_level
     type: enum
   default: debug
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMessage#message
@@ -8291,8 +8291,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMessage#tags
@@ -8305,7 +8305,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMessage#metadata
@@ -8318,7 +8318,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestMessage#created_at
@@ -8331,7 +8331,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8345,7 +8345,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8358,7 +8358,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8371,8 +8371,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMetadataMapping#target_entity_type
@@ -8384,8 +8384,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMetadataMapping#target_entity_id
@@ -8397,8 +8397,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMetadataMapping#field
@@ -8410,8 +8410,8 @@
   sql_type_metadata:
     sql_type: harvest_metadata_mapping_field
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMetadataMapping#pattern
@@ -8423,8 +8423,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestMetadataMapping#created_at
@@ -8437,7 +8437,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8451,7 +8451,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8464,7 +8464,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8477,8 +8477,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#status
@@ -8491,7 +8491,7 @@
     sql_type: harvest_record_status
     type: enum
   default: pending
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestRecord#identifier
@@ -8503,8 +8503,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#metadata_format
@@ -8516,8 +8516,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#raw_source
@@ -8529,8 +8529,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#raw_metadata_source
@@ -8542,8 +8542,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#entity_count
@@ -8556,8 +8556,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#source_changed_at
@@ -8569,8 +8569,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestRecord#created_at
@@ -8583,7 +8583,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8597,7 +8597,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8611,7 +8611,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestRecord#skipped
@@ -8624,7 +8624,7 @@
     sql_type: jsonb
     type: jsonb
   default: '{"active": false}'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestRecord#harvest_configuration_id
@@ -8636,8 +8636,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#id
@@ -8649,7 +8649,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8662,8 +8662,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#identifier
@@ -8675,8 +8675,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#name
@@ -8688,8 +8688,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#description
@@ -8701,8 +8701,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#raw_source
@@ -8714,8 +8714,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#metadata
@@ -8728,7 +8728,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSet#estimated_record_count
@@ -8741,8 +8741,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#last_harvested_at
@@ -8754,8 +8754,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSet#created_at
@@ -8768,7 +8768,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8782,7 +8782,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8795,7 +8795,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8808,8 +8808,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSetRecordLink#harvest_record_id
@@ -8821,8 +8821,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSetRecordLink#created_at
@@ -8835,7 +8835,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8849,7 +8849,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -8862,7 +8862,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -8875,8 +8875,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#protocol
@@ -8889,7 +8889,7 @@
     sql_type: harvest_protocol
     type: enum
   default: unknown
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSource#metadata_format
@@ -8901,8 +8901,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#base_url
@@ -8914,8 +8914,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#description
@@ -8927,8 +8927,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#list_options
@@ -8941,7 +8941,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSource#read_options
@@ -8954,7 +8954,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSource#format_options
@@ -8967,7 +8967,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSource#mapping_options
@@ -8980,7 +8980,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSource#sets_refreshed_at
@@ -8992,8 +8992,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#last_harvested_at
@@ -9005,8 +9005,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#created_at
@@ -9019,7 +9019,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9033,7 +9033,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9046,8 +9046,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#extraction_mapping_template
@@ -9060,7 +9060,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: HarvestSource#checked_at
@@ -9072,8 +9072,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HarvestSource#status
@@ -9086,7 +9086,20 @@
     sql_type: harvest_source_status
     type: enum
   default: inactive
-  default_function: 
+  default_function:
+  has_default: true
+  virtual: false
+- id: HarvestSource#allow_insecure
+  model_name: HarvestSource
+  table_name: harvest_sources
+  name: allow_insecure
+  type: boolean
+  'null': false
+  sql_type_metadata:
+    sql_type: boolean
+    type: boolean
+  default: 'false'
+  default_function:
   has_default: true
   virtual: false
 - id: HierarchicalSchemaRank#entity_type
@@ -9098,8 +9111,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaRank#entity_id
@@ -9111,8 +9124,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaRank#schema_definition_id
@@ -9124,8 +9137,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaRank#distinct_version_count
@@ -9138,8 +9151,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaRank#schema_count
@@ -9152,8 +9165,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaRank#schema_rank
@@ -9166,8 +9179,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaVersionRank#entity_type
@@ -9179,8 +9192,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaVersionRank#entity_id
@@ -9192,8 +9205,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaVersionRank#schema_definition_id
@@ -9205,8 +9218,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaVersionRank#schema_version_id
@@ -9218,8 +9231,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaVersionRank#schema_count
@@ -9232,8 +9245,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: HierarchicalSchemaVersionRank#schema_rank
@@ -9246,8 +9259,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#id
@@ -9259,7 +9272,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -9272,8 +9285,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#schema_definition_id
@@ -9285,8 +9298,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#parent_id
@@ -9298,8 +9311,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#identifier
@@ -9311,8 +9324,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#system_slug
@@ -9324,8 +9337,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#title
@@ -9337,8 +9350,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#raw_doi
@@ -9350,8 +9363,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#summary
@@ -9364,7 +9377,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Item#thumbnail_data
@@ -9376,8 +9389,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#properties
@@ -9389,8 +9402,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#created_at
@@ -9403,7 +9416,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9417,7 +9430,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9430,8 +9443,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#hierarchical_depth
@@ -9444,7 +9457,7 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
+  default:
   default_function: nlevel(auth_path)
   has_default: false
   virtual: true
@@ -9457,8 +9470,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#hero_image_data
@@ -9470,8 +9483,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#subtitle
@@ -9483,8 +9496,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#issn
@@ -9496,8 +9509,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Item#has_doi
@@ -9510,7 +9523,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Item#doi_data
@@ -9523,7 +9536,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Item#doi
@@ -9535,7 +9548,7 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
+  default:
   default_function: extract_doi_from_data(doi_data)
   has_default: false
   virtual: true
@@ -9549,7 +9562,7 @@
     sql_type: harvest_modification_status
     type: enum
   default: unharvested
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: ItemAttribution#id
@@ -9561,7 +9574,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -9574,8 +9587,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemAttribution#contributor_id
@@ -9587,8 +9600,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemAttribution#position
@@ -9601,8 +9614,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemAttribution#created_at
@@ -9615,7 +9628,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9629,7 +9642,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9642,8 +9655,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemAuthorization#collection_id
@@ -9655,8 +9668,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemAuthorization#item_id
@@ -9668,8 +9681,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemAuthorization#auth_path
@@ -9681,8 +9694,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#id
@@ -9694,7 +9707,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -9707,8 +9720,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#item_id
@@ -9720,8 +9733,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#kind
@@ -9733,8 +9746,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#metadata
@@ -9746,8 +9759,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#created_at
@@ -9760,7 +9773,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9774,7 +9787,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9787,8 +9800,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#inner_position
@@ -9801,8 +9814,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemContribution#outer_position
@@ -9815,8 +9828,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemHierarchy#ancestor_id
@@ -9828,8 +9841,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemHierarchy#descendant_id
@@ -9841,8 +9854,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: ItemHierarchy#generations
@@ -9855,8 +9868,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LatestHarvestAttemptLink#harvest_source_id
@@ -9868,8 +9881,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LatestHarvestAttemptLink#harvest_set_id
@@ -9881,8 +9894,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LatestHarvestAttemptLink#harvest_mapping_id
@@ -9894,8 +9907,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LatestHarvestAttemptLink#harvest_attempt_id
@@ -9907,8 +9920,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LayoutInvalidation#id
@@ -9920,7 +9933,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -9933,8 +9946,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LayoutInvalidation#entity_id
@@ -9946,8 +9959,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LayoutInvalidation#stale_at
@@ -9959,7 +9972,7 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9973,7 +9986,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -9987,7 +10000,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10000,7 +10013,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10013,8 +10026,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroDefinition#entity_type
@@ -10026,8 +10039,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroDefinition#entity_id
@@ -10039,8 +10052,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroDefinition#layout_kind
@@ -10053,7 +10066,7 @@
     sql_type: layout_kind
     type: enum
   default: hero
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::HeroDefinition#root
@@ -10065,7 +10078,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NULL) AND (entity_id IS NULL))"
   has_default: false
   virtual: true
@@ -10078,7 +10091,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NOT NULL) AND (entity_id IS NOT NULL))"
   has_default: false
   virtual: true
@@ -10092,7 +10105,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10106,7 +10119,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10120,7 +10133,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::HeroInstance#id
@@ -10132,7 +10145,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10145,8 +10158,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroInstance#entity_type
@@ -10158,8 +10171,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroInstance#entity_id
@@ -10171,8 +10184,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroInstance#layout_kind
@@ -10185,7 +10198,7 @@
     sql_type: layout_kind
     type: enum
   default: hero
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::HeroInstance#generation
@@ -10197,8 +10210,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroInstance#last_rendered_at
@@ -10210,8 +10223,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroInstance#render_duration
@@ -10223,8 +10236,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::HeroInstance#created_at
@@ -10237,7 +10250,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10251,7 +10264,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10265,7 +10278,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::ListItemDefinition#id
@@ -10277,7 +10290,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10290,8 +10303,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemDefinition#entity_type
@@ -10303,8 +10316,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemDefinition#entity_id
@@ -10316,8 +10329,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemDefinition#layout_kind
@@ -10330,7 +10343,7 @@
     sql_type: layout_kind
     type: enum
   default: list_item
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::ListItemDefinition#root
@@ -10342,7 +10355,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NULL) AND (entity_id IS NULL))"
   has_default: false
   virtual: true
@@ -10355,7 +10368,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NOT NULL) AND (entity_id IS NOT NULL))"
   has_default: false
   virtual: true
@@ -10369,7 +10382,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10383,7 +10396,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10397,7 +10410,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::ListItemInstance#id
@@ -10409,7 +10422,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10422,8 +10435,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemInstance#entity_type
@@ -10435,8 +10448,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemInstance#entity_id
@@ -10448,8 +10461,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemInstance#layout_kind
@@ -10462,7 +10475,7 @@
     sql_type: layout_kind
     type: enum
   default: list_item
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::ListItemInstance#generation
@@ -10474,8 +10487,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemInstance#last_rendered_at
@@ -10487,8 +10500,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemInstance#render_duration
@@ -10500,8 +10513,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::ListItemInstance#created_at
@@ -10514,7 +10527,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10528,7 +10541,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10542,7 +10555,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MainDefinition#id
@@ -10554,7 +10567,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10567,8 +10580,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainDefinition#entity_type
@@ -10580,8 +10593,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainDefinition#entity_id
@@ -10593,8 +10606,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainDefinition#layout_kind
@@ -10607,7 +10620,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MainDefinition#root
@@ -10619,7 +10632,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NULL) AND (entity_id IS NULL))"
   has_default: false
   virtual: true
@@ -10632,7 +10645,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NOT NULL) AND (entity_id IS NOT NULL))"
   has_default: false
   virtual: true
@@ -10646,7 +10659,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10660,7 +10673,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10674,7 +10687,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MainInstance#id
@@ -10686,7 +10699,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10699,8 +10712,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainInstance#entity_type
@@ -10712,8 +10725,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainInstance#entity_id
@@ -10725,8 +10738,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainInstance#layout_kind
@@ -10739,7 +10752,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MainInstance#generation
@@ -10751,8 +10764,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainInstance#last_rendered_at
@@ -10764,8 +10777,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainInstance#render_duration
@@ -10777,8 +10790,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MainInstance#created_at
@@ -10791,7 +10804,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10805,7 +10818,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10819,7 +10832,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MetadataDefinition#id
@@ -10831,7 +10844,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10844,8 +10857,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataDefinition#entity_type
@@ -10857,8 +10870,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataDefinition#entity_id
@@ -10870,8 +10883,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataDefinition#layout_kind
@@ -10884,7 +10897,7 @@
     sql_type: layout_kind
     type: enum
   default: metadata
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MetadataDefinition#root
@@ -10896,7 +10909,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NULL) AND (entity_id IS NULL))"
   has_default: false
   virtual: true
@@ -10909,7 +10922,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NOT NULL) AND (entity_id IS NOT NULL))"
   has_default: false
   virtual: true
@@ -10923,7 +10936,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10937,7 +10950,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -10951,7 +10964,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MetadataInstance#id
@@ -10963,7 +10976,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -10976,8 +10989,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataInstance#entity_type
@@ -10989,8 +11002,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataInstance#entity_id
@@ -11002,8 +11015,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataInstance#layout_kind
@@ -11016,7 +11029,7 @@
     sql_type: layout_kind
     type: enum
   default: metadata
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::MetadataInstance#generation
@@ -11028,8 +11041,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataInstance#last_rendered_at
@@ -11041,8 +11054,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataInstance#render_duration
@@ -11054,8 +11067,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::MetadataInstance#created_at
@@ -11068,7 +11081,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11082,7 +11095,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11096,7 +11109,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::NavigationDefinition#id
@@ -11108,7 +11121,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -11121,8 +11134,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationDefinition#entity_type
@@ -11134,8 +11147,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationDefinition#entity_id
@@ -11147,8 +11160,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationDefinition#layout_kind
@@ -11161,7 +11174,7 @@
     sql_type: layout_kind
     type: enum
   default: navigation
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::NavigationDefinition#root
@@ -11173,7 +11186,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NULL) AND (entity_id IS NULL))"
   has_default: false
   virtual: true
@@ -11186,7 +11199,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NOT NULL) AND (entity_id IS NOT NULL))"
   has_default: false
   virtual: true
@@ -11200,7 +11213,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11214,7 +11227,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11228,7 +11241,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::NavigationInstance#id
@@ -11240,7 +11253,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -11253,8 +11266,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationInstance#entity_type
@@ -11266,8 +11279,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationInstance#entity_id
@@ -11279,8 +11292,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationInstance#layout_kind
@@ -11293,7 +11306,7 @@
     sql_type: layout_kind
     type: enum
   default: navigation
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::NavigationInstance#generation
@@ -11305,8 +11318,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationInstance#last_rendered_at
@@ -11318,8 +11331,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationInstance#render_duration
@@ -11331,8 +11344,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::NavigationInstance#created_at
@@ -11345,7 +11358,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11359,7 +11372,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11373,7 +11386,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::SupplementaryDefinition#id
@@ -11385,7 +11398,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -11398,8 +11411,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryDefinition#entity_type
@@ -11411,8 +11424,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryDefinition#entity_id
@@ -11424,8 +11437,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryDefinition#layout_kind
@@ -11438,7 +11451,7 @@
     sql_type: layout_kind
     type: enum
   default: supplementary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::SupplementaryDefinition#root
@@ -11450,7 +11463,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NULL) AND (entity_id IS NULL))"
   has_default: false
   virtual: true
@@ -11463,7 +11476,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((entity_type IS NOT NULL) AND (entity_id IS NOT NULL))"
   has_default: false
   virtual: true
@@ -11477,7 +11490,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11491,7 +11504,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11505,7 +11518,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::SupplementaryInstance#id
@@ -11517,7 +11530,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -11530,8 +11543,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryInstance#entity_type
@@ -11543,8 +11556,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryInstance#entity_id
@@ -11556,8 +11569,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryInstance#layout_kind
@@ -11570,7 +11583,7 @@
     sql_type: layout_kind
     type: enum
   default: supplementary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Layouts::SupplementaryInstance#generation
@@ -11582,8 +11595,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryInstance#last_rendered_at
@@ -11595,8 +11608,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryInstance#render_duration
@@ -11608,8 +11621,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Layouts::SupplementaryInstance#created_at
@@ -11622,7 +11635,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11636,7 +11649,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11650,7 +11663,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: LinkTargetCandidate#source_type
@@ -11662,8 +11675,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#source_id
@@ -11675,8 +11688,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#source_slug
@@ -11688,8 +11701,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#target_type
@@ -11701,8 +11714,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#target_id
@@ -11714,8 +11727,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#auth_path
@@ -11727,8 +11740,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#system_slug
@@ -11740,8 +11753,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#depth
@@ -11754,8 +11767,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#title
@@ -11767,8 +11780,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#collection_id
@@ -11780,8 +11793,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#item_id
@@ -11793,8 +11806,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#created_at
@@ -11807,8 +11820,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: LinkTargetCandidate#updated_at
@@ -11821,8 +11834,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: NamedVariableDate#id
@@ -11834,7 +11847,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -11847,8 +11860,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: NamedVariableDate#entity_id
@@ -11860,8 +11873,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: NamedVariableDate#schema_version_property_id
@@ -11873,8 +11886,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: NamedVariableDate#path
@@ -11886,8 +11899,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: NamedVariableDate#actual
@@ -11900,7 +11913,7 @@
     sql_type: variable_precision_date
     type: variable_precision_date
   default: "(,none)"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: NamedVariableDate#created_at
@@ -11913,7 +11926,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11927,7 +11940,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -11940,7 +11953,7 @@
   sql_type_metadata:
     sql_type: date_precision
     type: enum
-  default: 
+  default:
   default_function: "(~> actual)"
   has_default: false
   virtual: true
@@ -11953,7 +11966,7 @@
   sql_type_metadata:
     sql_type: date_precision
     type: enum
-  default: 
+  default:
   default_function: |2-
 
     CASE
@@ -11971,7 +11984,7 @@
   sql_type_metadata:
     sql_type: daterange
     type: daterange
-  default: 
+  default:
   default_function: "(@& actual)"
   has_default: false
   virtual: true
@@ -11984,7 +11997,7 @@
   sql_type_metadata:
     sql_type: variable_precision_date
     type: variable_precision_date
-  default: 
+  default:
   default_function: "(# actual)"
   has_default: false
   virtual: true
@@ -11997,7 +12010,7 @@
   sql_type_metadata:
     sql_type: date
     type: date
-  default: 
+  default:
   default_function: "(~^ actual)"
   has_default: false
   virtual: true
@@ -12010,7 +12023,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -12023,8 +12036,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#entity_id
@@ -12036,8 +12049,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#schema_version_id
@@ -12049,8 +12062,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#community_id
@@ -12062,8 +12075,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#collection_id
@@ -12075,8 +12088,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#item_id
@@ -12088,8 +12101,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#identifier
@@ -12101,8 +12114,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#inherited_from_schema
@@ -12115,7 +12128,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Ordering#definition
@@ -12128,7 +12141,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Ordering#disabled_at
@@ -12140,8 +12153,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#created_at
@@ -12154,7 +12167,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -12168,7 +12181,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -12181,8 +12194,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#refreshed_at
@@ -12194,8 +12207,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#stale
@@ -12207,7 +12220,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "((stale_at IS NOT NULL) AND ((refreshed_at IS NULL) OR (refreshed_at
     < stale_at)))"
   has_default: false
@@ -12221,7 +12234,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: "(definition ->> 'name'::text)"
   has_default: false
   virtual: true
@@ -12235,8 +12248,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#position
@@ -12249,8 +12262,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Ordering#pristine
@@ -12263,7 +12276,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Ordering#paths
@@ -12275,7 +12288,7 @@
   sql_type_metadata:
     sql_type: text[]
     type: text
-  default: 
+  default:
   default_function: jsonb_to_text_array(jsonb_path_query_array(definition, '$."order"[*]."path"'::jsonpath))
   has_default: false
   virtual: true
@@ -12288,7 +12301,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: COALESCE(jsonb_to_boolean((definition -> 'hidden'::text)), false)
   has_default: false
   virtual: true
@@ -12301,7 +12314,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: COALESCE(jsonb_to_boolean((definition -> 'constant'::text)), false)
   has_default: false
   virtual: true
@@ -12314,7 +12327,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "(disabled_at IS NOT NULL)"
   has_default: false
   virtual: true
@@ -12327,8 +12340,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#id
@@ -12340,7 +12353,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -12353,8 +12366,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#entity_type
@@ -12366,8 +12379,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#entity_id
@@ -12379,8 +12392,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#position
@@ -12393,8 +12406,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#inverse_position
@@ -12407,8 +12420,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#link_operator
@@ -12420,8 +12433,8 @@
   sql_type_metadata:
     sql_type: link_operator
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#auth_path
@@ -12433,8 +12446,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#scope
@@ -12446,8 +12459,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#relative_depth
@@ -12460,8 +12473,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#tree_depth
@@ -12474,8 +12487,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#tree_parent_type
@@ -12487,8 +12500,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#tree_parent_id
@@ -12500,8 +12513,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#stale_at
@@ -12514,8 +12527,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntry#created_at
@@ -12528,7 +12541,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -12542,7 +12555,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -12556,7 +12569,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: OrderingEntryAncestorLink#id
@@ -12568,7 +12581,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -12581,8 +12594,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryAncestorLink#child_id
@@ -12594,8 +12607,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryAncestorLink#ancestor_id
@@ -12607,8 +12620,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryAncestorLink#inverse_depth
@@ -12621,8 +12634,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryAncestorLink#created_at
@@ -12635,7 +12648,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -12649,7 +12662,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -12662,8 +12675,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#entity_id
@@ -12675,8 +12688,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#hierarchical_type
@@ -12688,8 +12701,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#hierarchical_id
@@ -12701,8 +12714,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#auth_path
@@ -12714,8 +12727,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#scope
@@ -12727,8 +12740,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_version_id
@@ -12740,8 +12753,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#link_operator
@@ -12753,8 +12766,8 @@
   sql_type_metadata:
     sql_type: link_operator
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#entity_depth
@@ -12767,8 +12780,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#entity_title
@@ -12780,8 +12793,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#entity_created_at
@@ -12794,8 +12807,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#entity_updated_at
@@ -12808,8 +12821,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#entity_properties
@@ -12821,8 +12834,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_namespace
@@ -12834,8 +12847,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_identifier
@@ -12847,8 +12860,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_kind
@@ -12860,8 +12873,8 @@
   sql_type_metadata:
     sql_type: schema_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_number
@@ -12873,8 +12886,8 @@
   sql_type_metadata:
     sql_type: semantic_version
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_parsed_number
@@ -12886,8 +12899,8 @@
   sql_type_metadata:
     sql_type: parsed_semver
     type: parsed_semantic_version
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_version_slug
@@ -12899,8 +12912,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCandidate#schema_name
@@ -12912,8 +12925,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCount#ordering_id
@@ -12925,8 +12938,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCount#visible_count
@@ -12939,8 +12952,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntryCount#entries_count
@@ -12953,8 +12966,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntrySiblingLink#id
@@ -12966,7 +12979,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -12979,8 +12992,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntrySiblingLink#sibling_id
@@ -12992,8 +13005,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntrySiblingLink#prev_id
@@ -13005,8 +13018,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntrySiblingLink#next_id
@@ -13018,8 +13031,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingEntrySiblingLink#created_at
@@ -13032,7 +13045,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13046,7 +13059,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13059,7 +13072,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -13072,8 +13085,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: OrderingInvalidation#stale_at
@@ -13085,7 +13098,7 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13099,7 +13112,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13113,7 +13126,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13126,7 +13139,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -13139,8 +13152,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Page#entity_id
@@ -13152,8 +13165,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Page#position
@@ -13167,7 +13180,7 @@
     type: integer
     limit: 4
   default: '0'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Page#title
@@ -13179,8 +13192,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Page#slug
@@ -13192,8 +13205,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Page#body
@@ -13205,8 +13218,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Page#hero_image_data
@@ -13218,8 +13231,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Page#created_at
@@ -13232,7 +13245,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13246,7 +13259,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13259,8 +13272,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: PendingRoleAssignment#accessible_id
@@ -13272,8 +13285,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: PendingRoleAssignment#role_id
@@ -13285,8 +13298,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: PendingRoleAssignment#subject_type
@@ -13298,8 +13311,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: PendingRoleAssignment#subject_id
@@ -13311,8 +13324,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Permission#id
@@ -13324,7 +13337,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -13337,8 +13350,8 @@
   sql_type_metadata:
     sql_type: permission_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Permission#path
@@ -13350,8 +13363,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Permission#created_at
@@ -13364,7 +13377,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13378,7 +13391,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13391,7 +13404,7 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
+  default:
   default_function: subpath(path, 0, '-1'::integer)
   has_default: false
   virtual: true
@@ -13404,7 +13417,7 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
+  default:
   default_function: subpath(path, '-1'::integer, 1)
   has_default: false
   virtual: true
@@ -13417,7 +13430,7 @@
   sql_type_metadata:
     sql_type: text[]
     type: text
-  default: 
+  default:
   default_function: string_to_array((path)::text, '.'::text)
   has_default: false
   virtual: true
@@ -13430,7 +13443,7 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
+  default:
   default_function: "(path ~ 'self.*'::lquery)"
   has_default: false
   virtual: true
@@ -13443,7 +13456,7 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
+  default:
   default_function: subpath(path, 1, 1)
   has_default: false
   virtual: true
@@ -13456,7 +13469,7 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
+  default:
   default_function: subpath(path, 1, (nlevel(path) - 1))
   has_default: false
   virtual: true
@@ -13469,7 +13482,7 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
+  default:
   default_function: subpath(path, 0, 1)
   has_default: false
   virtual: true
@@ -13483,7 +13496,7 @@
     sql_type: ltree[]
     type: ltree
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: PrimaryRoleAssignment#subject_id
@@ -13495,8 +13508,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: PrimaryRoleAssignment#subject_type
@@ -13508,8 +13521,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: PrimaryRoleAssignment#role_id
@@ -13521,8 +13534,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RelatedCollectionLink#source_id
@@ -13534,8 +13547,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RelatedCollectionLink#target_id
@@ -13547,8 +13560,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RelatedCollectionLink#schema_version_id
@@ -13560,8 +13573,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RelatedItemLink#source_id
@@ -13573,8 +13586,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RelatedItemLink#target_id
@@ -13586,8 +13599,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RelatedItemLink#schema_version_id
@@ -13599,8 +13612,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Role#id
@@ -13612,7 +13625,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -13625,8 +13638,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Role#access_control_list
@@ -13639,7 +13652,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Role#created_at
@@ -13652,7 +13665,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13666,7 +13679,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13679,8 +13692,8 @@
   sql_type_metadata:
     sql_type: role_identifier
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Role#custom_priority
@@ -13693,8 +13706,8 @@
     sql_type: smallint
     type: integer
     limit: 2
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Role#global_access_control_list
@@ -13707,7 +13720,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Role#primacy
@@ -13719,7 +13732,7 @@
   sql_type_metadata:
     sql_type: role_primacy
     type: enum
-  default: 
+  default:
   default_function: calculate_role_primacy(identifier)
   has_default: false
   virtual: true
@@ -13732,7 +13745,7 @@
   sql_type_metadata:
     sql_type: role_kind
     type: enum
-  default: 
+  default:
   default_function: calculate_role_kind(identifier)
   has_default: false
   virtual: true
@@ -13746,7 +13759,7 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
+  default:
   default_function: calculate_role_priority(identifier, custom_priority)
   has_default: false
   virtual: true
@@ -13759,7 +13772,7 @@
   sql_type_metadata:
     sql_type: ltree[]
     type: ltree
-  default: 
+  default:
   default_function: calculate_allowed_actions(access_control_list)
   has_default: false
   virtual: true
@@ -13772,7 +13785,7 @@
   sql_type_metadata:
     sql_type: ltree[]
     type: ltree
-  default: 
+  default:
   default_function: calculate_allowed_actions(global_access_control_list)
   has_default: false
   virtual: true
@@ -13785,7 +13798,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -13798,8 +13811,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RolePermission#role_id
@@ -13811,8 +13824,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RolePermission#action
@@ -13824,8 +13837,8 @@
   sql_type_metadata:
     sql_type: ltree
     type: ltree
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: RolePermission#inferring_actions
@@ -13838,7 +13851,7 @@
     sql_type: ltree[]
     type: ltree
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: RolePermission#inferring_scopes
@@ -13851,7 +13864,7 @@
     sql_type: ltree[]
     type: ltree
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: RolePermission#inferred
@@ -13864,7 +13877,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: RolePermission#created_at
@@ -13877,7 +13890,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13891,7 +13904,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13904,7 +13917,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -13917,8 +13930,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinition#identifier
@@ -13930,8 +13943,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinition#kind
@@ -13943,8 +13956,8 @@
   sql_type_metadata:
     sql_type: schema_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinition#created_at
@@ -13957,7 +13970,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13971,7 +13984,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -13984,8 +13997,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinition#declaration
@@ -13997,7 +14010,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: "(((namespace)::text || ':'::text) || (identifier)::text)"
   has_default: false
   virtual: true
@@ -14010,8 +14023,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#path
@@ -14023,8 +14036,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#type
@@ -14036,8 +14049,8 @@
   sql_type_metadata:
     sql_type: schema_property_type
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#kind
@@ -14049,8 +14062,8 @@
   sql_type_metadata:
     sql_type: schema_property_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#label
@@ -14062,8 +14075,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#array
@@ -14075,8 +14088,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#nested
@@ -14088,8 +14101,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#orderable
@@ -14101,8 +14114,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#required
@@ -14114,8 +14127,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#extract_path
@@ -14127,8 +14140,8 @@
   sql_type_metadata:
     sql_type: text[]
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#metadata
@@ -14140,8 +14153,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#default_value
@@ -14153,8 +14166,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#current
@@ -14166,8 +14179,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#versions
@@ -14179,8 +14192,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#covered_version_ids
@@ -14192,8 +14205,8 @@
   sql_type_metadata:
     sql_type: uuid[]
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#version_count
@@ -14206,8 +14219,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#created_at
@@ -14219,8 +14232,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaDefinitionProperty#updated_at
@@ -14232,8 +14245,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersion#id
@@ -14245,7 +14258,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -14258,8 +14271,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersion#current
@@ -14272,7 +14285,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#configuration
@@ -14285,7 +14298,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#created_at
@@ -14298,7 +14311,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -14312,7 +14325,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -14326,8 +14339,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersion#collected_reference_paths
@@ -14340,7 +14353,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#scalar_reference_paths
@@ -14353,7 +14366,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#text_reference_paths
@@ -14366,7 +14379,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#name
@@ -14378,7 +14391,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: "(configuration ->> 'name'::text)"
   has_default: false
   virtual: true
@@ -14391,7 +14404,7 @@
   sql_type_metadata:
     sql_type: schema_kind
     type: enum
-  default: 
+  default:
   default_function: to_schema_kind((configuration ->> 'kind'::text))
   has_default: false
   virtual: true
@@ -14404,7 +14417,7 @@
   sql_type_metadata:
     sql_type: semantic_version
     type: citext
-  default: 
+  default:
   default_function: "(configuration ->> 'version'::text)"
   has_default: false
   virtual: true
@@ -14417,7 +14430,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: "(configuration ->> 'namespace'::text)"
   has_default: false
   virtual: true
@@ -14430,7 +14443,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: "(configuration ->> 'identifier'::text)"
   has_default: false
   virtual: true
@@ -14443,7 +14456,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: "(((((configuration ->> 'namespace'::text) || ':'::text) || (configuration
     ->> 'identifier'::text)) || ':'::text) || (configuration ->> 'version'::text))"
   has_default: false
@@ -14457,7 +14470,7 @@
   sql_type_metadata:
     sql_type: parsed_semver
     type: parsed_semantic_version
-  default: 
+  default:
   default_function: parse_semver((configuration ->> 'version'::text))
   has_default: false
   virtual: true
@@ -14470,7 +14483,7 @@
   sql_type_metadata:
     sql_type: text[]
     type: text
-  default: 
+  default:
   default_function: jsonb_to_text_array(jsonb_path_query_array(configuration, '$."orderings"[*]."id"'::jsonpath))
   has_default: false
   virtual: true
@@ -14484,7 +14497,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#enforces_children
@@ -14497,7 +14510,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#enforced_parent_declarations
@@ -14510,7 +14523,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#enforced_child_declarations
@@ -14523,7 +14536,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#has_ancestors
@@ -14536,7 +14549,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#ancestor_names
@@ -14549,7 +14562,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#enforced_parent_kinds
@@ -14562,7 +14575,7 @@
     sql_type: schema_kind[]
     type: enum
   default: "{community,collection,item}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersion#enforced_child_kinds
@@ -14575,7 +14588,7 @@
     sql_type: child_entity_kind[]
     type: enum
   default: "{collection,item}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionAncestor#id
@@ -14587,7 +14600,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -14600,8 +14613,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionAncestor#target_version_id
@@ -14613,8 +14626,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionAncestor#name
@@ -14626,8 +14639,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionAncestor#created_at
@@ -14640,7 +14653,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -14654,7 +14667,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -14667,7 +14680,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -14680,8 +14693,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionAssociation#target_id
@@ -14693,8 +14706,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionAssociation#name
@@ -14706,8 +14719,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionAssociation#created_at
@@ -14720,7 +14733,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -14734,7 +14747,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -14747,8 +14760,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#identifier
@@ -14760,8 +14773,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#name
@@ -14773,8 +14786,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#schema_position
@@ -14787,8 +14800,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#definition_index
@@ -14801,8 +14814,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#constant
@@ -14814,8 +14827,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#hidden
@@ -14827,8 +14840,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#render_mode
@@ -14840,8 +14853,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#paths
@@ -14853,8 +14866,8 @@
   sql_type_metadata:
     sql_type: text[]
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#paths_with_direction
@@ -14866,8 +14879,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionOrdering#definition
@@ -14879,8 +14892,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#id
@@ -14892,7 +14905,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -14905,8 +14918,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#schema_definition_id
@@ -14918,8 +14931,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#position
@@ -14932,8 +14945,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#array
@@ -14946,7 +14959,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#nested
@@ -14959,7 +14972,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#orderable
@@ -14972,7 +14985,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#required
@@ -14985,7 +14998,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#kind
@@ -14998,7 +15011,7 @@
     sql_type: schema_property_kind
     type: enum
   default: simple
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#type
@@ -15010,8 +15023,8 @@
   sql_type_metadata:
     sql_type: schema_property_type
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#path
@@ -15023,8 +15036,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#label
@@ -15036,8 +15049,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#extract_path
@@ -15049,8 +15062,8 @@
   sql_type_metadata:
     sql_type: text[]
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchemaVersionProperty#metadata
@@ -15063,7 +15076,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#created_at
@@ -15076,7 +15089,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15090,7 +15103,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15103,7 +15116,7 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
+  default:
   default_function: "(metadata -> 'default'::text)"
   has_default: false
   virtual: true
@@ -15117,7 +15130,7 @@
     sql_type: schema_property_function
     type: enum
   default: unspecified
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchemaVersionProperty#searchable
@@ -15130,7 +15143,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchematicCollectedReference#id
@@ -15142,7 +15155,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -15155,8 +15168,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicCollectedReference#referrer_id
@@ -15168,8 +15181,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicCollectedReference#referent_type
@@ -15181,8 +15194,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicCollectedReference#referent_id
@@ -15194,8 +15207,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicCollectedReference#path
@@ -15207,8 +15220,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicCollectedReference#position
@@ -15221,8 +15234,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicCollectedReference#created_at
@@ -15235,7 +15248,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15249,7 +15262,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15262,7 +15275,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -15275,8 +15288,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicScalarReference#referrer_id
@@ -15288,8 +15301,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicScalarReference#referent_type
@@ -15301,8 +15314,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicScalarReference#referent_id
@@ -15314,8 +15327,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicScalarReference#path
@@ -15327,8 +15340,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicScalarReference#created_at
@@ -15341,7 +15354,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15355,7 +15368,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15368,7 +15381,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -15381,8 +15394,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicText#entity_id
@@ -15394,8 +15407,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicText#path
@@ -15407,8 +15420,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicText#lang
@@ -15420,8 +15433,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicText#kind
@@ -15434,7 +15447,7 @@
     sql_type: citext
     type: citext
   default: text
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchematicText#dictionary
@@ -15447,7 +15460,7 @@
     sql_type: regconfig
     type: regconfig
   default: simple
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchematicText#weight
@@ -15460,7 +15473,7 @@
     sql_type: full_text_weight
     type: string
   default: D
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: SchematicText#content
@@ -15472,8 +15485,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicText#text_content
@@ -15485,8 +15498,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: SchematicText#created_at
@@ -15499,7 +15512,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15513,7 +15526,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15526,7 +15539,7 @@
   sql_type_metadata:
     sql_type: tsvector
     type: tsvector
-  default: 
+  default:
   default_function: setweight(to_tsvector(dictionary, text_content), (weight)::"char")
   has_default: false
   virtual: true
@@ -15539,8 +15552,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbDefinition#id
@@ -15552,7 +15565,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -15565,8 +15578,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbDefinition#layout_kind
@@ -15579,7 +15592,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbDefinition#template_kind
@@ -15592,7 +15605,7 @@
     sql_type: template_kind
     type: enum
   default: blurb
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbDefinition#background
@@ -15605,7 +15618,7 @@
     sql_type: blurb_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbDefinition#width
@@ -15618,7 +15631,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbDefinition#position
@@ -15631,8 +15644,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbDefinition#created_at
@@ -15645,7 +15658,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15659,7 +15672,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15673,7 +15686,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbDefinition#slots
@@ -15686,7 +15699,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbInstance#id
@@ -15698,7 +15711,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -15711,8 +15724,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#template_definition_id
@@ -15724,8 +15737,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#entity_type
@@ -15737,8 +15750,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#entity_id
@@ -15750,8 +15763,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#layout_kind
@@ -15764,7 +15777,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbInstance#template_kind
@@ -15777,7 +15790,7 @@
     sql_type: template_kind
     type: enum
   default: blurb
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbInstance#generation
@@ -15789,8 +15802,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#position
@@ -15803,8 +15816,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#last_rendered_at
@@ -15816,8 +15829,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#render_duration
@@ -15829,8 +15842,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::BlurbInstance#created_at
@@ -15843,7 +15856,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15857,7 +15870,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15871,7 +15884,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::BlurbInstance#slots
@@ -15884,7 +15897,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#id
@@ -15896,7 +15909,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -15909,8 +15922,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListDefinition#layout_kind
@@ -15923,7 +15936,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#template_kind
@@ -15936,7 +15949,7 @@
     sql_type: template_kind
     type: enum
   default: contributor_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#position
@@ -15949,8 +15962,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListDefinition#created_at
@@ -15963,7 +15976,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15977,7 +15990,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -15991,7 +16004,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#slots
@@ -16004,7 +16017,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#background
@@ -16017,7 +16030,7 @@
     sql_type: contributor_list_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#limit
@@ -16030,8 +16043,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListDefinition#filter
@@ -16044,7 +16057,7 @@
     sql_type: contributor_list_filter
     type: enum
   default: all
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListDefinition#width
@@ -16057,7 +16070,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListInstance#id
@@ -16069,7 +16082,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -16082,8 +16095,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#template_definition_id
@@ -16095,8 +16108,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#entity_type
@@ -16108,8 +16121,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#entity_id
@@ -16121,8 +16134,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#layout_kind
@@ -16135,7 +16148,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListInstance#template_kind
@@ -16148,7 +16161,7 @@
     sql_type: template_kind
     type: enum
   default: contributor_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListInstance#generation
@@ -16160,8 +16173,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#position
@@ -16174,8 +16187,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#last_rendered_at
@@ -16187,8 +16200,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#render_duration
@@ -16200,8 +16213,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ContributorListInstance#created_at
@@ -16214,7 +16227,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -16228,7 +16241,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -16242,7 +16255,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ContributorListInstance#slots
@@ -16255,7 +16268,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DerivedInstanceDigest#template_instance_id
@@ -16267,8 +16280,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#template_instance_type
@@ -16280,8 +16293,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#template_definition_id
@@ -16293,8 +16306,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#template_definition_type
@@ -16306,8 +16319,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#layout_instance_id
@@ -16319,8 +16332,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#layout_instance_type
@@ -16332,8 +16345,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#layout_definition_id
@@ -16345,8 +16358,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#layout_definition_type
@@ -16358,8 +16371,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#entity_id
@@ -16371,8 +16384,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#entity_type
@@ -16384,8 +16397,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#position
@@ -16398,8 +16411,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#layout_kind
@@ -16411,8 +16424,8 @@
   sql_type_metadata:
     sql_type: layout_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#template_kind
@@ -16424,8 +16437,8 @@
   sql_type_metadata:
     sql_type: template_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#width
@@ -16437,8 +16450,8 @@
   sql_type_metadata:
     sql_type: template_width
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#generation
@@ -16450,8 +16463,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#config
@@ -16463,8 +16476,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#slots
@@ -16476,8 +16489,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#last_rendered_at
@@ -16489,8 +16502,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#render_duration
@@ -16502,8 +16515,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#created_at
@@ -16516,8 +16529,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DerivedInstanceDigest#updated_at
@@ -16530,8 +16543,8 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#id
@@ -16543,7 +16556,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -16556,8 +16569,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#layout_kind
@@ -16570,7 +16583,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#template_kind
@@ -16583,7 +16596,7 @@
     sql_type: template_kind
     type: enum
   default: descendant_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#position
@@ -16596,8 +16609,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#created_at
@@ -16610,7 +16623,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -16624,7 +16637,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -16638,7 +16651,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#slots
@@ -16651,7 +16664,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#background
@@ -16664,7 +16677,7 @@
     sql_type: descendant_list_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#variant
@@ -16677,7 +16690,7 @@
     sql_type: descendant_list_variant
     type: enum
   default: cards
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#selection_source_mode
@@ -16690,7 +16703,7 @@
     sql_type: selection_source_mode
     type: enum
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#selection_mode
@@ -16703,7 +16716,7 @@
     sql_type: descendant_list_selection_mode
     type: enum
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#selection_source
@@ -16716,7 +16729,7 @@
     sql_type: text
     type: text
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#title
@@ -16728,8 +16741,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#selection_limit
@@ -16742,8 +16755,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#dynamic_ordering_definition
@@ -16755,8 +16768,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#ordering_identifier
@@ -16768,8 +16781,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#see_all_button_label
@@ -16781,8 +16794,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#show_see_all_button
@@ -16795,7 +16808,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#show_entity_context
@@ -16808,7 +16821,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#manual_list_name
@@ -16821,7 +16834,7 @@
     sql_type: text
     type: text
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#selection_source_ancestor_name
@@ -16833,8 +16846,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#selection_property_path
@@ -16846,8 +16859,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#show_hero_image
@@ -16860,7 +16873,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#use_selection_fallback
@@ -16873,7 +16886,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#selection_fallback_mode
@@ -16886,7 +16899,7 @@
     sql_type: descendant_list_selection_mode
     type: enum
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#width
@@ -16899,7 +16912,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#see_all_ordering_identifier
@@ -16911,8 +16924,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListDefinition#show_contributors
@@ -16925,7 +16938,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#show_nested_entities
@@ -16938,7 +16951,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#entity_context
@@ -16951,7 +16964,7 @@
     sql_type: list_entity_context
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListDefinition#browse_style
@@ -16964,7 +16977,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListInstance#id
@@ -16976,7 +16989,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -16989,8 +17002,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#template_definition_id
@@ -17002,8 +17015,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#entity_type
@@ -17015,8 +17028,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#entity_id
@@ -17028,8 +17041,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#layout_kind
@@ -17042,7 +17055,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListInstance#template_kind
@@ -17055,7 +17068,7 @@
     sql_type: template_kind
     type: enum
   default: descendant_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListInstance#generation
@@ -17067,8 +17080,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#position
@@ -17081,8 +17094,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#last_rendered_at
@@ -17094,8 +17107,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#render_duration
@@ -17107,8 +17120,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DescendantListInstance#created_at
@@ -17121,7 +17134,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17135,7 +17148,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17149,7 +17162,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListInstance#slots
@@ -17162,7 +17175,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DescendantListInstance#see_all_ordering_id
@@ -17174,8 +17187,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailDefinition#id
@@ -17187,7 +17200,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -17200,8 +17213,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailDefinition#layout_kind
@@ -17214,7 +17227,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#template_kind
@@ -17227,7 +17240,7 @@
     sql_type: template_kind
     type: enum
   default: detail
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#position
@@ -17240,8 +17253,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailDefinition#created_at
@@ -17254,7 +17267,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17268,7 +17281,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17282,7 +17295,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#slots
@@ -17295,7 +17308,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#background
@@ -17308,7 +17321,7 @@
     sql_type: detail_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#variant
@@ -17321,7 +17334,7 @@
     sql_type: detail_variant
     type: enum
   default: summary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#show_announcements
@@ -17334,7 +17347,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#show_hero_image
@@ -17347,7 +17360,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#show_body
@@ -17360,7 +17373,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailDefinition#width
@@ -17373,7 +17386,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailInstance#id
@@ -17385,7 +17398,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -17398,8 +17411,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#template_definition_id
@@ -17411,8 +17424,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#entity_type
@@ -17424,8 +17437,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#entity_id
@@ -17437,8 +17450,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#layout_kind
@@ -17451,7 +17464,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailInstance#template_kind
@@ -17464,7 +17477,7 @@
     sql_type: template_kind
     type: enum
   default: detail
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailInstance#generation
@@ -17476,8 +17489,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#position
@@ -17490,8 +17503,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#last_rendered_at
@@ -17503,8 +17516,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#render_duration
@@ -17516,8 +17529,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::DetailInstance#created_at
@@ -17530,7 +17543,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17544,7 +17557,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17558,7 +17571,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::DetailInstance#slots
@@ -17571,7 +17584,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#id
@@ -17583,7 +17596,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -17596,8 +17609,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroDefinition#layout_kind
@@ -17610,7 +17623,7 @@
     sql_type: layout_kind
     type: enum
   default: hero
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#template_kind
@@ -17623,7 +17636,7 @@
     sql_type: template_kind
     type: enum
   default: hero
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#position
@@ -17636,8 +17649,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroDefinition#created_at
@@ -17650,7 +17663,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17664,7 +17677,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -17678,7 +17691,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#slots
@@ -17691,7 +17704,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#background
@@ -17704,7 +17717,7 @@
     sql_type: hero_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#enable_descendant_browsing
@@ -17717,7 +17730,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#enable_descendant_search
@@ -17730,7 +17743,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#list_contributors
@@ -17743,7 +17756,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_basic_view_metrics
@@ -17756,7 +17769,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_big_search_prompt
@@ -17769,7 +17782,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_breadcrumbs
@@ -17782,7 +17795,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_doi
@@ -17795,7 +17808,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_hero_image
@@ -17808,7 +17821,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_issn
@@ -17821,7 +17834,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_sharing_link
@@ -17834,7 +17847,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_split_display
@@ -17847,7 +17860,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#show_thumbnail_image
@@ -17860,7 +17873,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroDefinition#descendant_search_prompt
@@ -17872,8 +17885,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#id
@@ -17885,7 +17898,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -17898,8 +17911,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#template_definition_id
@@ -17911,8 +17924,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#entity_type
@@ -17924,8 +17937,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#entity_id
@@ -17937,8 +17950,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#layout_kind
@@ -17951,7 +17964,7 @@
     sql_type: layout_kind
     type: enum
   default: hero
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroInstance#template_kind
@@ -17964,7 +17977,7 @@
     sql_type: template_kind
     type: enum
   default: hero
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroInstance#generation
@@ -17976,8 +17989,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#position
@@ -17990,8 +18003,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#last_rendered_at
@@ -18003,8 +18016,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#render_duration
@@ -18016,8 +18029,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::HeroInstance#created_at
@@ -18030,7 +18043,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -18044,7 +18057,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -18058,7 +18071,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::HeroInstance#slots
@@ -18071,7 +18084,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::InstanceDigest#id
@@ -18083,7 +18096,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -18096,8 +18109,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#template_instance_id
@@ -18109,8 +18122,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#template_definition_type
@@ -18122,8 +18135,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#template_definition_id
@@ -18135,8 +18148,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#layout_instance_type
@@ -18148,8 +18161,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#layout_instance_id
@@ -18161,8 +18174,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#layout_definition_type
@@ -18174,8 +18187,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#layout_definition_id
@@ -18187,8 +18200,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#entity_type
@@ -18200,8 +18213,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#entity_id
@@ -18213,8 +18226,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#position
@@ -18227,8 +18240,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#layout_kind
@@ -18240,8 +18253,8 @@
   sql_type_metadata:
     sql_type: layout_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#template_kind
@@ -18253,8 +18266,8 @@
   sql_type_metadata:
     sql_type: template_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#width
@@ -18266,8 +18279,8 @@
   sql_type_metadata:
     sql_type: template_width
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#generation
@@ -18279,8 +18292,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#config
@@ -18293,7 +18306,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::InstanceDigest#slots
@@ -18306,7 +18319,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::InstanceDigest#render_duration
@@ -18318,8 +18331,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#last_rendered_at
@@ -18331,8 +18344,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceDigest#created_at
@@ -18345,7 +18358,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -18359,7 +18372,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -18372,8 +18385,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#template_instance_id
@@ -18385,8 +18398,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#sibling_instance_type
@@ -18398,8 +18411,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#sibling_instance_id
@@ -18411,8 +18424,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#position
@@ -18425,8 +18438,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#kind
@@ -18438,8 +18451,8 @@
   sql_type_metadata:
     sql_type: sibling_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#dark
@@ -18451,8 +18464,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#config
@@ -18464,8 +18477,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#layout_kind
@@ -18477,8 +18490,8 @@
   sql_type_metadata:
     sql_type: layout_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#template_kind
@@ -18490,8 +18503,8 @@
   sql_type_metadata:
     sql_type: template_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::InstanceSibling#width
@@ -18503,8 +18516,8 @@
   sql_type_metadata:
     sql_type: template_width
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#id
@@ -18516,7 +18529,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -18529,8 +18542,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#layout_kind
@@ -18543,7 +18556,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#template_kind
@@ -18556,7 +18569,7 @@
     sql_type: template_kind
     type: enum
   default: link_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#position
@@ -18569,8 +18582,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#created_at
@@ -18583,7 +18596,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -18597,7 +18610,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -18611,7 +18624,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#slots
@@ -18624,7 +18637,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#background
@@ -18637,7 +18650,7 @@
     sql_type: link_list_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#variant
@@ -18650,7 +18663,7 @@
     sql_type: link_list_variant
     type: enum
   default: cards
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#selection_source_mode
@@ -18663,7 +18676,7 @@
     sql_type: selection_source_mode
     type: enum
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#selection_mode
@@ -18676,7 +18689,7 @@
     sql_type: link_list_selection_mode
     type: enum
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#selection_source
@@ -18689,7 +18702,7 @@
     sql_type: text
     type: text
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#title
@@ -18701,8 +18714,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#selection_limit
@@ -18715,8 +18728,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#dynamic_ordering_definition
@@ -18728,8 +18741,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#see_all_button_label
@@ -18741,8 +18754,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#show_see_all_button
@@ -18755,7 +18768,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#show_entity_context
@@ -18768,7 +18781,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#manual_list_name
@@ -18781,7 +18794,7 @@
     sql_type: text
     type: text
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#selection_source_ancestor_name
@@ -18793,8 +18806,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#show_hero_image
@@ -18807,7 +18820,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#use_selection_fallback
@@ -18820,7 +18833,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#selection_fallback_mode
@@ -18833,7 +18846,7 @@
     sql_type: link_list_selection_mode
     type: enum
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#width
@@ -18846,7 +18859,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#see_all_ordering_identifier
@@ -18858,8 +18871,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListDefinition#show_contributors
@@ -18872,7 +18885,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#show_nested_entities
@@ -18885,7 +18898,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#entity_context
@@ -18898,7 +18911,7 @@
     sql_type: list_entity_context
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListDefinition#browse_style
@@ -18911,7 +18924,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListInstance#id
@@ -18923,7 +18936,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -18936,8 +18949,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#template_definition_id
@@ -18949,8 +18962,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#entity_type
@@ -18962,8 +18975,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#entity_id
@@ -18975,8 +18988,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#layout_kind
@@ -18989,7 +19002,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListInstance#template_kind
@@ -19002,7 +19015,7 @@
     sql_type: template_kind
     type: enum
   default: link_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListInstance#generation
@@ -19014,8 +19027,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#position
@@ -19028,8 +19041,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#last_rendered_at
@@ -19041,8 +19054,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#render_duration
@@ -19054,8 +19067,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::LinkListInstance#created_at
@@ -19068,7 +19081,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19082,7 +19095,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19096,7 +19109,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListInstance#slots
@@ -19109,7 +19122,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::LinkListInstance#see_all_ordering_id
@@ -19121,8 +19134,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#id
@@ -19134,7 +19147,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -19147,8 +19160,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#layout_kind
@@ -19161,7 +19174,7 @@
     sql_type: layout_kind
     type: enum
   default: list_item
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#template_kind
@@ -19174,7 +19187,7 @@
     sql_type: template_kind
     type: enum
   default: list_item
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#position
@@ -19187,8 +19200,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#created_at
@@ -19201,7 +19214,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19215,7 +19228,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19229,7 +19242,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#slots
@@ -19242,7 +19255,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#use_selection_fallback
@@ -19255,7 +19268,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#selection_limit
@@ -19268,8 +19281,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#selection_mode
@@ -19282,7 +19295,7 @@
     sql_type: list_item_selection_mode
     type: enum
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#selection_fallback_mode
@@ -19295,7 +19308,7 @@
     sql_type: list_item_selection_mode
     type: enum
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#selection_source_mode
@@ -19308,7 +19321,7 @@
     sql_type: selection_source_mode
     type: enum
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#dynamic_ordering_definition
@@ -19320,8 +19333,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#ordering_identifier
@@ -19333,8 +19346,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#selection_source
@@ -19347,7 +19360,7 @@
     sql_type: text
     type: text
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#manual_list_name
@@ -19360,7 +19373,7 @@
     sql_type: text
     type: text
   default: manual
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemDefinition#selection_source_ancestor_name
@@ -19372,8 +19385,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#selection_property_path
@@ -19385,8 +19398,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemDefinition#see_all_ordering_identifier
@@ -19398,8 +19411,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#id
@@ -19411,7 +19424,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -19424,8 +19437,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#template_definition_id
@@ -19437,8 +19450,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#entity_type
@@ -19450,8 +19463,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#entity_id
@@ -19463,8 +19476,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#layout_kind
@@ -19477,7 +19490,7 @@
     sql_type: layout_kind
     type: enum
   default: list_item
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemInstance#template_kind
@@ -19490,7 +19503,7 @@
     sql_type: template_kind
     type: enum
   default: list_item
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemInstance#generation
@@ -19502,8 +19515,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#position
@@ -19516,8 +19529,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#last_rendered_at
@@ -19529,8 +19542,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#render_duration
@@ -19542,8 +19555,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ListItemInstance#created_at
@@ -19556,7 +19569,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19570,7 +19583,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19584,7 +19597,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemInstance#slots
@@ -19597,7 +19610,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::ListItemInstance#see_all_ordering_id
@@ -19609,8 +19622,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#id
@@ -19622,7 +19635,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -19635,8 +19648,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#layout_definition_id
@@ -19648,8 +19661,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#template_definition_type
@@ -19661,8 +19674,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#template_definition_id
@@ -19674,8 +19687,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#layout_kind
@@ -19687,8 +19700,8 @@
   sql_type_metadata:
     sql_type: layout_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#template_kind
@@ -19700,8 +19713,8 @@
   sql_type_metadata:
     sql_type: template_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#list_name
@@ -19713,8 +19726,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualList#created_at
@@ -19727,7 +19740,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19741,7 +19754,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19754,7 +19767,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -19767,8 +19780,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#source_id
@@ -19780,8 +19793,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#target_type
@@ -19793,8 +19806,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#target_id
@@ -19806,8 +19819,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#template_kind
@@ -19819,8 +19832,8 @@
   sql_type_metadata:
     sql_type: template_kind
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#list_name
@@ -19832,8 +19845,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#position
@@ -19846,8 +19859,8 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::ManualListEntry#created_at
@@ -19860,7 +19873,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19874,7 +19887,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19887,7 +19900,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -19900,8 +19913,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataDefinition#layout_kind
@@ -19914,7 +19927,7 @@
     sql_type: layout_kind
     type: enum
   default: metadata
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataDefinition#template_kind
@@ -19927,7 +19940,7 @@
     sql_type: template_kind
     type: enum
   default: metadata
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataDefinition#position
@@ -19940,8 +19953,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataDefinition#created_at
@@ -19954,7 +19967,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19968,7 +19981,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -19982,7 +19995,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataDefinition#slots
@@ -19995,7 +20008,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataDefinition#background
@@ -20008,7 +20021,7 @@
     sql_type: metadata_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataInstance#id
@@ -20020,7 +20033,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -20033,8 +20046,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#template_definition_id
@@ -20046,8 +20059,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#entity_type
@@ -20059,8 +20072,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#entity_id
@@ -20072,8 +20085,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#layout_kind
@@ -20086,7 +20099,7 @@
     sql_type: layout_kind
     type: enum
   default: metadata
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataInstance#template_kind
@@ -20099,7 +20112,7 @@
     sql_type: template_kind
     type: enum
   default: metadata
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataInstance#generation
@@ -20111,8 +20124,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#position
@@ -20125,8 +20138,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#last_rendered_at
@@ -20138,8 +20151,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#render_duration
@@ -20151,8 +20164,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::MetadataInstance#created_at
@@ -20165,7 +20178,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20179,7 +20192,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20193,7 +20206,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::MetadataInstance#slots
@@ -20206,7 +20219,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationDefinition#id
@@ -20218,7 +20231,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -20231,8 +20244,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationDefinition#layout_kind
@@ -20245,7 +20258,7 @@
     sql_type: layout_kind
     type: enum
   default: navigation
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationDefinition#template_kind
@@ -20258,7 +20271,7 @@
     sql_type: template_kind
     type: enum
   default: navigation
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationDefinition#position
@@ -20271,8 +20284,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationDefinition#created_at
@@ -20285,7 +20298,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20299,7 +20312,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20313,7 +20326,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationDefinition#slots
@@ -20326,7 +20339,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationDefinition#background
@@ -20339,7 +20352,7 @@
     sql_type: navigation_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationInstance#id
@@ -20351,7 +20364,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -20364,8 +20377,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#template_definition_id
@@ -20377,8 +20390,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#entity_type
@@ -20390,8 +20403,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#entity_id
@@ -20403,8 +20416,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#layout_kind
@@ -20417,7 +20430,7 @@
     sql_type: layout_kind
     type: enum
   default: navigation
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationInstance#template_kind
@@ -20430,7 +20443,7 @@
     sql_type: template_kind
     type: enum
   default: navigation
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationInstance#generation
@@ -20442,8 +20455,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#position
@@ -20456,8 +20469,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#last_rendered_at
@@ -20469,8 +20482,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#render_duration
@@ -20482,8 +20495,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::NavigationInstance#created_at
@@ -20496,7 +20509,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20510,7 +20523,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20524,7 +20537,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::NavigationInstance#slots
@@ -20537,7 +20550,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#id
@@ -20549,7 +20562,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -20562,8 +20575,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingDefinition#layout_kind
@@ -20576,7 +20589,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#template_kind
@@ -20589,7 +20602,7 @@
     sql_type: template_kind
     type: enum
   default: ordering
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#position
@@ -20602,8 +20615,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingDefinition#created_at
@@ -20616,7 +20629,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20630,7 +20643,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20644,7 +20657,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#slots
@@ -20657,7 +20670,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#background
@@ -20670,7 +20683,7 @@
     sql_type: ordering_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#ordering_source_mode
@@ -20683,7 +20696,7 @@
     sql_type: selection_source_mode
     type: enum
   default: parent
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#ordering_source
@@ -20696,7 +20709,7 @@
     sql_type: text
     type: text
   default: parent
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#ordering_source_ancestor_name
@@ -20708,8 +20721,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingDefinition#selection_source_mode
@@ -20722,7 +20735,7 @@
     sql_type: selection_source_mode
     type: enum
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#selection_source
@@ -20735,7 +20748,7 @@
     sql_type: text
     type: text
   default: self
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingDefinition#selection_source_ancestor_name
@@ -20747,8 +20760,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingDefinition#ordering_identifier
@@ -20760,8 +20773,8 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingDefinition#width
@@ -20774,7 +20787,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingInstance#id
@@ -20786,7 +20799,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -20799,8 +20812,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#template_definition_id
@@ -20812,8 +20825,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#entity_type
@@ -20825,8 +20838,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#entity_id
@@ -20838,8 +20851,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#layout_kind
@@ -20852,7 +20865,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingInstance#template_kind
@@ -20865,7 +20878,7 @@
     sql_type: template_kind
     type: enum
   default: ordering
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingInstance#generation
@@ -20877,8 +20890,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#position
@@ -20891,8 +20904,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#last_rendered_at
@@ -20904,8 +20917,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#render_duration
@@ -20917,8 +20930,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#created_at
@@ -20931,7 +20944,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20945,7 +20958,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -20959,7 +20972,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingInstance#slots
@@ -20972,7 +20985,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::OrderingInstance#ordering_id
@@ -20984,8 +20997,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::OrderingInstance#ordering_entry_id
@@ -20997,8 +21010,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListDefinition#id
@@ -21010,7 +21023,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -21023,8 +21036,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListDefinition#layout_kind
@@ -21037,7 +21050,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListDefinition#template_kind
@@ -21050,7 +21063,7 @@
     sql_type: template_kind
     type: enum
   default: page_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListDefinition#position
@@ -21063,8 +21076,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListDefinition#created_at
@@ -21077,7 +21090,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21091,7 +21104,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21105,7 +21118,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListDefinition#slots
@@ -21118,7 +21131,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListDefinition#background
@@ -21131,7 +21144,7 @@
     sql_type: page_list_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListDefinition#width
@@ -21144,7 +21157,7 @@
     sql_type: template_width
     type: enum
   default: full
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListInstance#id
@@ -21156,7 +21169,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -21169,8 +21182,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#template_definition_id
@@ -21182,8 +21195,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#entity_type
@@ -21195,8 +21208,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#entity_id
@@ -21208,8 +21221,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#layout_kind
@@ -21222,7 +21235,7 @@
     sql_type: layout_kind
     type: enum
   default: main
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListInstance#template_kind
@@ -21235,7 +21248,7 @@
     sql_type: template_kind
     type: enum
   default: page_list
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListInstance#generation
@@ -21247,8 +21260,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#position
@@ -21261,8 +21274,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#last_rendered_at
@@ -21274,8 +21287,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#render_duration
@@ -21287,8 +21300,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::PageListInstance#created_at
@@ -21301,7 +21314,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21315,7 +21328,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21329,7 +21342,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::PageListInstance#slots
@@ -21342,7 +21355,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryDefinition#id
@@ -21354,7 +21367,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -21367,8 +21380,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryDefinition#layout_kind
@@ -21381,7 +21394,7 @@
     sql_type: layout_kind
     type: enum
   default: supplementary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryDefinition#template_kind
@@ -21394,7 +21407,7 @@
     sql_type: template_kind
     type: enum
   default: supplementary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryDefinition#position
@@ -21407,8 +21420,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryDefinition#created_at
@@ -21421,7 +21434,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21435,7 +21448,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21449,7 +21462,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryDefinition#slots
@@ -21462,7 +21475,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryDefinition#background
@@ -21475,7 +21488,7 @@
     sql_type: supplementary_background
     type: enum
   default: none
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryInstance#id
@@ -21487,7 +21500,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -21500,8 +21513,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#template_definition_id
@@ -21513,8 +21526,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#entity_type
@@ -21526,8 +21539,8 @@
   sql_type_metadata:
     sql_type: character varying
     type: string
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#entity_id
@@ -21539,8 +21552,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#layout_kind
@@ -21553,7 +21566,7 @@
     sql_type: layout_kind
     type: enum
   default: supplementary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryInstance#template_kind
@@ -21566,7 +21579,7 @@
     sql_type: template_kind
     type: enum
   default: supplementary
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryInstance#generation
@@ -21578,8 +21591,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#position
@@ -21592,8 +21605,8 @@
     sql_type: bigint
     type: integer
     limit: 8
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#last_rendered_at
@@ -21605,8 +21618,8 @@
   sql_type_metadata:
     sql_type: timestamp without time zone
     type: datetime
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#render_duration
@@ -21618,8 +21631,8 @@
   sql_type_metadata:
     sql_type: numeric
     type: decimal
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: Templates::SupplementaryInstance#created_at
@@ -21632,7 +21645,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21646,7 +21659,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21660,7 +21673,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: Templates::SupplementaryInstance#slots
@@ -21673,7 +21686,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#id
@@ -21685,7 +21698,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -21698,8 +21711,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: User#system_slug
@@ -21711,8 +21724,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: User#email_verified
@@ -21725,7 +21738,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#email
@@ -21737,8 +21750,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: User#username
@@ -21750,8 +21763,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: User#name
@@ -21764,7 +21777,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#given_name
@@ -21777,7 +21790,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#family_name
@@ -21790,7 +21803,7 @@
     sql_type: text
     type: text
   default: ''
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#roles
@@ -21803,7 +21816,7 @@
     sql_type: text[]
     type: text
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#resource_roles
@@ -21816,7 +21829,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#metadata
@@ -21829,7 +21842,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#created_at
@@ -21842,7 +21855,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21856,7 +21869,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -21870,7 +21883,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#allowed_actions
@@ -21883,7 +21896,7 @@
     sql_type: ltree[]
     type: ltree
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#avatar_data
@@ -21895,8 +21908,8 @@
   sql_type_metadata:
     sql_type: jsonb
     type: jsonb
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: User#role_priority
@@ -21909,7 +21922,7 @@
     sql_type: integer
     type: integer
     limit: 4
-  default: 
+  default:
   default_function: user_role_priority(roles, metadata, allowed_actions)
   has_default: false
   virtual: true
@@ -21922,7 +21935,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: to_prefix_search(given_name)
   has_default: false
   virtual: true
@@ -21935,7 +21948,7 @@
   sql_type_metadata:
     sql_type: text
     type: text
-  default: 
+  default:
   default_function: to_prefix_search(family_name)
   has_default: false
   virtual: true
@@ -21949,7 +21962,7 @@
     sql_type: access_management
     type: enum
   default: forbidden
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#can_manage_access_globally
@@ -21962,7 +21975,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: User#can_manage_access_contextually
@@ -21975,7 +21988,7 @@
     sql_type: boolean
     type: boolean
   default: 'false'
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: UserAccessInfo#user_id
@@ -21987,8 +22000,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserAccessInfo#can_manage_access_globally
@@ -22000,8 +22013,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserAccessInfo#can_manage_access_contextually
@@ -22013,8 +22026,8 @@
   sql_type_metadata:
     sql_type: boolean
     type: boolean
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserAccessInfo#access_management
@@ -22026,8 +22039,8 @@
   sql_type_metadata:
     sql_type: access_management
     type: enum
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroup#id
@@ -22039,7 +22052,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -22052,8 +22065,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroup#system_slug
@@ -22065,8 +22078,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroup#name
@@ -22078,8 +22091,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroup#description
@@ -22091,8 +22104,8 @@
   sql_type_metadata:
     sql_type: citext
     type: citext
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroup#metadata
@@ -22105,7 +22118,7 @@
     sql_type: jsonb
     type: jsonb
   default: "{}"
-  default_function: 
+  default_function:
   has_default: true
   virtual: false
 - id: UserGroup#created_at
@@ -22118,7 +22131,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -22132,7 +22145,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -22145,7 +22158,7 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
+  default:
   default_function: gen_random_uuid()
   has_default: true
   virtual: false
@@ -22158,8 +22171,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroupMembership#user_group_id
@@ -22171,8 +22184,8 @@
   sql_type_metadata:
     sql_type: uuid
     type: uuid
-  default: 
-  default_function: 
+  default:
+  default_function:
   has_default: false
   virtual: false
 - id: UserGroupMembership#created_at
@@ -22185,7 +22198,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false
@@ -22199,7 +22212,7 @@
     sql_type: timestamp(6) without time zone
     type: datetime
     precision: 6
-  default: 
+  default:
   default_function: CURRENT_TIMESTAMP
   has_default: true
   virtual: false

--- a/lib/harvesting/examples/default_oaidc/template.xml
+++ b/lib/harvesting/examples/default_oaidc/template.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping>
+  <entities>
+    <item schema="nglp:paper">
+      <identifier>{{record.identifier}}</identifier>
+      <title>{{oaidc.title | first}}</title>
+      <doi>{{doi}}</doi>
+      <published>{{oaidc.date | first}}</published>
+      <properties>
+        <asset path="pdf_version">
+          <kind>pdf</kind>
+          <mime-type>application/pdf</mime-type>
+          <name>
+            paper.pdf
+          </name>
+          <url>
+            {{pdf.url}}
+          </url>
+        </asset>
+        <string path="host.title">{{oaidc.publisher | first}}</string>
+      </properties>
+      <contributions>
+        {% for creator in creators %}
+        {% contribution role: "aut" %}
+        {% person %}
+        {% given_name creator.given %}
+        {% family_name creator.family %}
+        {% endperson %}
+        {% endcontribution %}
+        {% endfor %}
+        {% for contributor in contributors %}
+        {% contribution role: "ctb" %}
+        {% person %}
+        {% given_name contributor.given %}
+        {% family_name contributor.family %}
+        {% endperson %}
+        {% endcontribution %}
+        {% endfor %}
+      </contributions>
+    </item>
+  </entities>
+</mapping>

--- a/lib/harvesting/examples/oaidc_journal_article/template.xml
+++ b/lib/harvesting/examples/oaidc_journal_article/template.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapping>
+  <entities>
+    <collection schema="nglp:journal_volume">
+      <requires>
+        <expr reason="must have a volume">{{journal.volume}}</expr>
+      </requires>
+      <identifier>volume-{{journal.volume}}</identifier>
+      <title>Volume {{journal.volume}}</title>
+      <properties>
+        <string path="id">{{journal.volume}}</string>
+        <integer path="sortable_number">{{journal.volume}}</integer>
+      </properties>
+      <collection schema="nglp:journal_issue">
+        <requires>
+          <expr reason="must have an issue">{{journal.issue}}</expr>
+        </requires>
+        <identifier>issue-{{journal.issue}}</identifier>
+        <title>Issue {{journal.issue}}</title>
+        <properties>
+          <string path="id">{{journal.issue}}</string>
+          <integer path="sortable_number">{{journal.issue}}</integer>
+        </properties>
+        <item schema="nglp:journal_article">
+          <identifier>{{record.identifier}}</identifier>
+          <title>{{oaidc.title | first}}</title>
+          <doi>{{doi}}</doi>
+          <published>{{oaidc.date | first}}</published>
+          <contributions>
+            {% for creator in creators %}
+            {% contribution role: "aut" %}
+            {% person %}
+            {% given_name creator.given %}
+            {% family_name creator.family %}
+            {% endperson %}
+            {% endcontribution %}
+            {% endfor %}
+            {% for contributor in contributors %}
+            {% contribution role: "ctb" %}
+            {% person %}
+            {% given_name contributor.given %}
+            {% family_name contributor.family %}
+            {% endperson %}
+            {% endcontribution %}
+            {% endfor %}
+          </contributions>
+          <properties>
+            <tags path="keywords">
+              {% for subject in oaidc.subject %}
+              {% tag %}{{subject}}{% endtag %}
+              {% endfor %}
+            </tags>
+            <asset path="pdf_version">
+              <kind>pdf</kind>
+              <mime-type>application/pdf</mime-type>
+              <name>PDF Version</name>
+              <url>
+                {{pdf.url}}
+              </url>
+            </asset>
+          </properties>
+        </item>
+      </collection>
+    </collection>
+  </entities>
+</mapping>


### PR DESCRIPTION
* Improve OAIDC liquid templates to extract certain structured data from OAIDC metadata
* Allow ability to backport harvesting templates for pilot communities
* Update local image to use bookworm debian
* Add private workaround for ignoring SSL when fetching over OAI-PMH