### PR TITLE
[E] Improve performance of dynamic orderings

### DIFF
--- a/app/jobs/entities/refresh_cached_ancestors_job.rb
+++ b/app/jobs/entities/refresh_cached_ancestors_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Entities
+  # @note Runs every 2 minutes
+  # @see EntityCachedAncestor
+  class RefreshCachedAncestorsJob < ApplicationJob
+    queue_as :maintenance
+
+    good_job_control_concurrency_with(
+      total_limit: 1
+    )
+
+    # @return [void]
+    def perform
+      EntityCachedAncestor.refresh!
+    end
+  end
+end

--- a/app/models/entity_cached_ancestor.rb
+++ b/app/models/entity_cached_ancestor.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Equivalent to {EntityAncestor}, except it is cached in order to use with
+# dynamic orderings in order to address performance issues on very large
+# entity trees.
+#
+# @see Entities::RefreshCachedAncestors
+class EntityCachedAncestor < ApplicationRecord
+  include HasEphemeralSystemSlug
+  include MaterializedView
+end

--- a/app/services/schemas/orderings/dynamic_resolver.rb
+++ b/app/services/schemas/orderings/dynamic_resolver.rb
@@ -6,6 +6,7 @@ module Schemas
     #
     # @see Schemas::Orderings::ResolveDynamic
     class DynamicResolver < Support::HookBased::Actor
+      include Dry::Effects::Handler.Reader(:for_dynamic_ordering)
       include Dry::Initializer[undefined: false].define -> do
         option :definition, ::Schemas::Types.Instance(::Schemas::Orderings::Definition)
 
@@ -17,6 +18,8 @@ module Schemas
       end
 
       standard_execution!
+
+      around_execute :set_for_dynamic_ordering!
 
       # @return [Schemas::Orderings::Dynamic]
       attr_reader :dynamic
@@ -60,6 +63,15 @@ module Schemas
         @entities = query.map(&:entity)
 
         super
+      end
+
+      private
+
+      # @return [void]
+      def set_for_dynamic_ordering!
+        with_for_dynamic_ordering(true) do
+          yield
+        end
       end
     end
   end

--- a/app/services/schemas/orderings/order_builder/base.rb
+++ b/app/services/schemas/orderings/order_builder/base.rb
@@ -8,6 +8,7 @@ module Schemas
         extend Dry::Initializer
 
         include Dry::Core::Memoizable
+        include Dry::Effects.Reader(:for_dynamic_ordering, default: false)
         include Dry::Effects.State(:joins)
         include Dry::Effects.State(:props)
         include Dry::Effects.Resolve(:encode_join)
@@ -39,7 +40,11 @@ module Schemas
         end
 
         memoize def entity_ancestors
-          EntityAncestor.arel_table
+          if for_dynamic_ordering
+            EntityCachedAncestor.arel_table
+          else
+            EntityAncestor.arel_table
+          end
         end
 
         memoize def named_variable_dates
@@ -77,13 +82,17 @@ module Schemas
         end
 
         def arel_quote(value)
+          # :nocov:
           Arel::Nodes.build_quoted value
+          # :nocov:
         end
 
         # @abstract
         # @return [<Arel::Attribute, Arel::OrderPredications>]
         def attributes_for(definition)
+          # :nocov:
           []
+          # :nocov:
         end
 
         # @api private
@@ -192,7 +201,9 @@ module Schemas
             source_alias[:entity_id].eq(table_alias[:entity_id])
           )
 
+          # :nocov:
           on_condition = yield on_condition if block_given?
+          # :nocov:
 
           on = Arel::Nodes::On.new on_condition
 

--- a/app/services/schemas/orderings/order_builder/by_schema_property.rb
+++ b/app/services/schemas/orderings/order_builder/by_schema_property.rb
@@ -20,7 +20,9 @@ module Schemas
 
           match = pattern.match order_path
 
+          # :nocov:
           raise "Unparseable schema path: #{order_path}" unless match
+          # :nocov:
 
           path = match[:path]
 

--- a/config/initializers/900_good_job.rb
+++ b/config/initializers/900_good_job.rb
@@ -88,10 +88,15 @@ Rails.application.configure do
       class: "Entities::RefreshAuthorContributionsJob",
       description: "Refresh author contributions",
     },
+    "entities.refresh_cached_ancestors": {
+      cron: "*/2 * * * *",
+      class: "Entities::RefreshCachedAncestorsJob",
+      description: "Refresh entity cached ancestors",
+    },
     "entities.reindex_all_search_documents": {
       cron: "9,19,29,39,49,59 * * * *",
       class: "Entities::ReindexAllSearchDocumentsJob",
-      description: "Refresh author contributions",
+      description: "Re-index all entity search documents",
     },
     "harvesting.attempts.enqueue_scheduled": {
       cron: "50 * * * *",

--- a/db/migrate/20250709172917_create_entity_cached_ancestors.rb
+++ b/db/migrate/20250709172917_create_entity_cached_ancestors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateEntityCachedAncestors < ActiveRecord::Migration[7.0]
+  def change
+    create_view :entity_cached_ancestors, materialized: true
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+        CREATE UNIQUE INDEX entity_cached_ancestors_pkey ON entity_cached_ancestors (entity_type, entity_id, name) INCLUDE (ancestor_type, ancestor_id);
+        SQL
+      end
+    end
+
+    change_table :entities do |t|
+      t.index %i[auth_path schema_version_id link_operator], name: "index_entities_schematic_descendant_querying", using: :gist
+    end
+  end
+end

--- a/db/views/entity_cached_ancestors_v01.sql
+++ b/db/views/entity_cached_ancestors_v01.sql
@@ -1,0 +1,20 @@
+SELECT DISTINCT ON (sva.name, ent.entity_id)
+  ent.entity_type,
+  ent.entity_id,
+  sva.name,
+  anc.entity_type AS ancestor_type,
+  anc.entity_id AS ancestor_id,
+  anc.schema_version_id AS ancestor_schema_version_id,
+  ent.depth AS origin_depth,
+  anc.depth AS ancestor_depth,
+  ent.depth - anc.depth AS relative_depth
+  FROM entities ent
+  INNER JOIN schema_version_ancestors sva USING (schema_version_id)
+  INNER JOIN entities anc ON
+    ent.auth_path <@ anc.auth_path
+    AND
+    anc.entity_id <> ent.entity_id
+    AND
+    anc.schema_version_id = sva.target_version_id
+  ORDER BY sva.name, ent.entity_id, anc.depth DESC
+;

--- a/lib/frozen_record/static_cached_columns.yml
+++ b/lib/frozen_record/static_cached_columns.yml
@@ -4707,6 +4707,126 @@
   default_function:
   has_default: false
   virtual: false
+- id: EntityCachedAncestor#entity_type
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: entity_type
+  type: text
+  'null': true
+  sql_type_metadata:
+    sql_type: text
+    type: text
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#entity_id
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: entity_id
+  type: uuid
+  'null': true
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#name
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: name
+  type: text
+  'null': true
+  sql_type_metadata:
+    sql_type: text
+    type: text
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#ancestor_type
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: ancestor_type
+  type: text
+  'null': true
+  sql_type_metadata:
+    sql_type: text
+    type: text
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#ancestor_id
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: ancestor_id
+  type: uuid
+  'null': true
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#ancestor_schema_version_id
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: ancestor_schema_version_id
+  type: uuid
+  'null': true
+  sql_type_metadata:
+    sql_type: uuid
+    type: uuid
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#origin_depth
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: origin_depth
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: integer
+    type: integer
+    limit: 4
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#ancestor_depth
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: ancestor_depth
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: integer
+    type: integer
+    limit: 4
+  default:
+  default_function:
+  has_default: false
+  virtual: false
+- id: EntityCachedAncestor#relative_depth
+  model_name: EntityCachedAncestor
+  table_name: entity_cached_ancestors
+  name: relative_depth
+  type: integer
+  'null': true
+  sql_type_metadata:
+    sql_type: integer
+    type: integer
+    limit: 4
+  default:
+  default_function:
+  has_default: false
+  virtual: false
 - id: EntityComposedText#id
   model_name: EntityComposedText
   table_name: entity_composed_texts

--- a/lib/support/model_concerns/materialized_view.rb
+++ b/lib/support/model_concerns/materialized_view.rb
@@ -10,7 +10,11 @@ module MaterializedView
     config.refreshes_concurrently = true
   end
 
-  class_methods do
+  module ClassMethods
+    def populated?
+      Scenic.database.populated?(table_name)
+    end
+
     # @return [void]
     def refresh!(concurrently: config.refreshes_concurrently, cascade: false)
       Scenic.database.refresh_materialized_view(table_name, concurrently:, cascade:)

--- a/spec/jobs/entities/refresh_cached_ancestors_job_spec.rb
+++ b/spec/jobs/entities/refresh_cached_ancestors_job_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe Entities::RefreshCachedAncestorsJob, type: :job do
+  it "executes safely" do
+    expect do
+      described_class.perform_now
+    end.to execute_safely
+  end
+end

--- a/spec/operations/schemas/orderings/resolve_dynamic_spec.rb
+++ b/spec/operations/schemas/orderings/resolve_dynamic_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Schemas::Orderings::ResolveDynamic, type: :operation do
+  let_it_be(:id) { SecureRandom.uuid }
+
+  let_it_be(:community, refind: true) { FactoryBot.create :community }
+
+  let_it_be(:journal, refind: true) { FactoryBot.create :collection, schema: "nglp:journal", community: }
+
+  let_it_be(:volume, refind: true) { FactoryBot.create :collection, schema: "nglp:journal_volume", community:, parent: journal, published: VariablePrecisionDate.parse("2025-07-09") }
+
+  let_it_be(:issue, refind: true) { FactoryBot.create :collection, schema: "nglp:journal_issue", community:, parent: volume, published: VariablePrecisionDate.parse("2025-07-09") }
+
+  let_it_be(:old_article, refind: true) do
+    FactoryBot.create(:item, schema: "nglp:journal_article", collection: issue, published: "2025-06-01")
+  end
+
+  let_it_be(:new_article, refind: true) do
+    FactoryBot.create(:item, schema: "nglp:journal_article", collection: issue, published: "2025-07-01")
+  end
+
+  let_it_be(:limit) { 5 }
+
+  let_it_be(:entity) { journal }
+
+  let_it_be(:definition) do
+    Schemas::Orderings::Definition.new(
+      order: [
+        { path: "ancestors.volume.published", direction: "desc", nulls: "first" },
+        { path: "ancestors.issue.published", direction: "desc", nulls: "last" },
+        { path: "ancestors.issue.props.sortable_number#integer", direction: "desc" },
+        { path: "entity.published", direction: "desc", },
+        { path: "props.nonexisting#boolean", direction: "desc" },
+        { path: "link.is_link" },
+        { path: "props.some_date#variable_date" },
+      ],
+      filter: {
+        schemas: [
+          {
+            namespace: "nglp",
+            identifier: "journal_article"
+          }
+        ]
+      },
+      select: {
+        direct: "descendants",
+      }
+    )
+  end
+
+  before do
+    EntityCachedAncestor.refresh!
+  end
+
+  it "retrieves things in the correct order" do
+    expect_calling_with(definition:, entity:, limit:, id:).to succeed.with([new_article, old_article])
+  end
+end


### PR DESCRIPTION
Add an EntityCachedAncestor materialized view that is equivalent to the EntityAncestor view, but cached so as to expedite dynamic query lookups in the template system. This view is refreshed periodically in a background job, but may occasionally be out of date. Since dynamic orderings are evaluated at request time, this should cause very little disruption, if any.